### PR TITLE
adapted license header to include The Grove Authors

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,3 +1,19 @@
+# /*
+# Copyright 2024 The Grove Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
 REPO_ROOT           := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 HACK_DIR            := $(REPO_ROOT)/hack
 

--- a/operator/api/config/v1alpha1/defaults.go
+++ b/operator/api/config/v1alpha1/defaults.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/api/config/v1alpha1/doc.go
+++ b/operator/api/config/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/api/config/v1alpha1/register.go
+++ b/operator/api/config/v1alpha1/register.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/api/config/v1alpha1/types.go
+++ b/operator/api/config/v1alpha1/types.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/api/config/validation/validation.go
+++ b/operator/api/config/validation/validation.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/api/podgangset/v1alpha1/doc.go
+++ b/operator/api/podgangset/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/api/podgangset/v1alpha1/register.go
+++ b/operator/api/podgangset/v1alpha1/register.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/api/podgangset/v1alpha1/types.go
+++ b/operator/api/podgangset/v1alpha1/types.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/cmd/opts/options.go
+++ b/operator/cmd/opts/options.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/hack/add-license-headers.sh
+++ b/operator/hack/add-license-headers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # /*
-# Copyright 2024.
+# Copyright 2024 The Grove Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operator/hack/build.sh
+++ b/operator/hack/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # /*
-# Copyright 2024.
+# Copyright 2024 The Grove Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operator/hack/format.sh
+++ b/operator/hack/format.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # /*
-# Copyright 2024.
+# Copyright 2024 The Grove Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operator/hack/generate-tls.sh
+++ b/operator/hack/generate-tls.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # /*
-# Copyright 2024.
+# Copyright 2024 The Grove Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operator/hack/generate.sh
+++ b/operator/hack/generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # /*
-# Copyright 2024.
+# Copyright 2024 The Grove Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operator/hack/install-helm-charts.sh
+++ b/operator/hack/install-helm-charts.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # /*
-# Copyright 2024.
+# Copyright 2024 The Grove Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operator/hack/kind-down.sh
+++ b/operator/hack/kind-down.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # /*
-# Copyright 2024.
+# Copyright 2024 The Grove Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operator/hack/kind-up.sh
+++ b/operator/hack/kind-up.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # /*
-# Copyright 2024.
+# Copyright 2024 The Grove Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/operator/hack/tools.go
+++ b/operator/hack/tools.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/hack/tools.mk
+++ b/operator/hack/tools.mk
@@ -1,3 +1,19 @@
+# /*
+# Copyright 2024 The Grove Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
 TOOLS_DIR 			:= $(HACK_DIR)/tools
 TOOLS_BIN_DIR       := $(TOOLS_DIR)/bin
 

--- a/operator/internal/client/scheme.go
+++ b/operator/internal/client/scheme.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/controller/config.go
+++ b/operator/internal/controller/config.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/controller/pgs/config.go
+++ b/operator/internal/controller/pgs/config.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/controller/pgs/reconciler.go
+++ b/operator/internal/controller/pgs/reconciler.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/controller/pgs/register.go
+++ b/operator/internal/controller/pgs/register.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/controller/podgangset/reconciler.go
+++ b/operator/internal/controller/podgangset/reconciler.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/controller/podgangset/register.go
+++ b/operator/internal/controller/podgangset/register.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/controller/register.go
+++ b/operator/internal/controller/register.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/logger/logger.go
+++ b/operator/internal/logger/logger.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/manager/config.go
+++ b/operator/internal/manager/config.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/manager/manager.go
+++ b/operator/internal/manager/manager.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/utils/miscellaneous.go
+++ b/operator/internal/utils/miscellaneous.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/version/version.go
+++ b/operator/internal/version/version.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/webhook/pgs/register.go
+++ b/operator/internal/webhook/pgs/register.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/webhook/pgs/validation/handler.go
+++ b/operator/internal/webhook/pgs/validation/handler.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/operator/internal/webhook/pgs/validation/register.go
+++ b/operator/internal/webhook/pgs/validation/register.go
@@ -1,5 +1,5 @@
 // /*
-// Copyright 2024.
+// Copyright 2024 The Grove Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Use the new license header for 
- *.go files
- *.sh files 
- Makefile and tools.mk