### PR TITLE
Specify defaults using annotations, use validating functions exposed by `apimachinery`, etc.

### DIFF
--- a/operator/api/core/v1alpha1/crds/grove.io_podgangsets.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podgangsets.yaml
@@ -237,6 +237,7 @@ spec:
                   that will be created in the PodGangSet.
                 properties:
                   cliqueStartupType:
+                    default: CliqueStartupTypeInOrder
                     description: |-
                       StartupType defines the type of startup dependency amongst the cliques within a PodGang.
                       If it is not defined then default of CliqueStartupTypeInOrder is used.

--- a/operator/api/core/v1alpha1/crds/grove.io_podgangsets.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podgangsets.yaml
@@ -9575,6 +9575,8 @@ spec:
                       type: object
                     type: array
                   schedulingPolicyConfig:
+                    default:
+                      networkPackStrategy: BestEffort
                     description: SchedulingPolicyConfig defines the scheduling policy
                       configuration for the PodGang.
                     properties:

--- a/operator/api/core/v1alpha1/podgangset.go
+++ b/operator/api/core/v1alpha1/podgangset.go
@@ -105,6 +105,7 @@ type PodGangTemplateSpec struct {
 	Cliques []*PodCliqueTemplateSpec `json:"cliques"`
 	// StartupType defines the type of startup dependency amongst the cliques within a PodGang.
 	// If it is not defined then default of CliqueStartupTypeInOrder is used.
+	// +kubebuilder:default=CliqueStartupTypeInOrder
 	// +optional
 	StartupType *CliqueStartupType `json:"cliqueStartupType,omitempty"`
 	// HeadlessServiceConfig defines the config options for the headless service.
@@ -179,7 +180,6 @@ type HeadlessServiceConfig struct {
 
 // CliqueStartupType defines the order in which each PodClique is started.
 // +kubebuilder:validation:Enum={CliqueStartupTypeInOrder,CliqueStartupTypeAnyOrder,CliqueStartupTypeExplicit}
-// +kubebuilder:default=CliqueStartupTypeInOrder
 type CliqueStartupType string
 
 const (

--- a/operator/api/core/v1alpha1/podgangset.go
+++ b/operator/api/core/v1alpha1/podgangset.go
@@ -113,6 +113,9 @@ type PodGangTemplateSpec struct {
 	// +optional
 	HeadlessServiceConfig *HeadlessServiceConfig `json:"headlessServiceConfig,omitempty"`
 	// SchedulingPolicyConfig defines the scheduling policy configuration for the PodGang.
+	// Defaulting only works for optional fields.
+	// See https://github.com/kubernetes-sigs/controller-tools/issues/893#issuecomment-1991256368
+	// +kubebuilder:default:={networkPackStrategy:BestEffort}
 	SchedulingPolicyConfig *SchedulingPolicyConfig `json:"schedulingPolicyConfig,omitempty"`
 	// PodCliqueScalingGroupConfigs is a list of scaling groups for the PodGangSet.
 	PodCliqueScalingGroupConfigs []PodCliqueScalingGroupConfig `json:"podCliqueScalingGroups,omitempty"`

--- a/operator/internal/webhook/admission/pgs/defaulting/podgangset.go
+++ b/operator/internal/webhook/admission/pgs/defaulting/podgangset.go
@@ -44,10 +44,6 @@ func defaultPodGangSetSpec(spec *grovecorev1alpha1.PodGangSetSpec) {
 func defaultPodGangTemplateSpec(spec *grovecorev1alpha1.PodGangTemplateSpec) {
 	// default PodCliqueTemplateSpecs
 	spec.Cliques = defaultPodCliqueTemplateSpecs(spec.Cliques)
-	// default startup type
-	if spec.StartupType == nil {
-		spec.StartupType = ptr.To(grovecorev1alpha1.CliqueStartupTypeInOrder)
-	}
 	// default NetworkPackStrategy
 	if spec.SchedulingPolicyConfig == nil {
 		spec.SchedulingPolicyConfig = &grovecorev1alpha1.SchedulingPolicyConfig{

--- a/operator/internal/webhook/admission/pgs/defaulting/podgangset.go
+++ b/operator/internal/webhook/admission/pgs/defaulting/podgangset.go
@@ -44,14 +44,6 @@ func defaultPodGangSetSpec(spec *grovecorev1alpha1.PodGangSetSpec) {
 func defaultPodGangTemplateSpec(spec *grovecorev1alpha1.PodGangTemplateSpec) {
 	// default PodCliqueTemplateSpecs
 	spec.Cliques = defaultPodCliqueTemplateSpecs(spec.Cliques)
-	// default NetworkPackStrategy
-	if spec.SchedulingPolicyConfig == nil {
-		spec.SchedulingPolicyConfig = &grovecorev1alpha1.SchedulingPolicyConfig{
-			NetworkPackStrategy: ptr.To(grovecorev1alpha1.BestEffort),
-		}
-	} else if spec.SchedulingPolicyConfig.NetworkPackStrategy == nil {
-		spec.SchedulingPolicyConfig.NetworkPackStrategy = ptr.To(grovecorev1alpha1.BestEffort)
-	}
 }
 
 func defaultUpdateStrategy(spec *grovecorev1alpha1.PodGangSetSpec) {

--- a/operator/internal/webhook/admission/pgs/validation/podgangset.go
+++ b/operator/internal/webhook/admission/pgs/validation/podgangset.go
@@ -68,16 +68,10 @@ func (v *pgsValidator) validate() ([]string, error) {
 // validateUpdate validates the update to a PodGangSet object. It compares the old and new PodGangSet objects and validates that the changes done are allowed/valid.
 func (v *pgsValidator) validateUpdate(oldPgs *grovecorev1alpha1.PodGangSet) error {
 	allErrs := field.ErrorList{}
-
 	fldPath := field.NewPath("spec")
-	if !reflect.DeepEqual(v.pgs.Spec.ReplicaSpreadConstraints, oldPgs.Spec.ReplicaSpreadConstraints) {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("replicaSpreadConstraints"), "field is immutable"))
-	}
-	if v.pgs.Spec.PriorityClassName != oldPgs.Spec.PriorityClassName {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("priorityClassName"), "field is immutable"))
-	}
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(v.pgs.Spec.ReplicaSpreadConstraints, oldPgs.Spec.ReplicaSpreadConstraints, fldPath.Child("replicaSpreadConstraints"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(v.pgs.Spec.PriorityClassName, oldPgs.Spec.PriorityClassName, fldPath.Child("priorityClassName"))...)
 	allErrs = append(allErrs, validatePodGangSetSpecUpdate(&v.pgs.Spec, &oldPgs.Spec, fldPath)...)
-
 	return allErrs.ToAggregate()
 }
 
@@ -373,9 +367,7 @@ func validatePodGangTemplateSpecUpdate(newSpec, oldSpec *grovecorev1alpha1.PodGa
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validatePodCliqueUpdate(newSpec.Cliques, oldSpec.Cliques, fldPath.Child("cliques"))...)
-	if *newSpec.StartupType != *oldSpec.StartupType {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("cliqueStartupType"), "field is immutable"))
-	}
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.StartupType, oldSpec.StartupType, fldPath.Child("cliqueStartupType"))...)
 	allErrs = append(allErrs, validatePodGangSchedulingPolicyConfigUpdate(newSpec.SchedulingPolicyConfig, newSpec.SchedulingPolicyConfig, fldPath.Child("schedulingPolicyConfig"))...)
 
 	return allErrs
@@ -383,10 +375,7 @@ func validatePodGangTemplateSpecUpdate(newSpec, oldSpec *grovecorev1alpha1.PodGa
 
 func validatePodGangSchedulingPolicyConfigUpdate(newConfig, oldConfig *grovecorev1alpha1.SchedulingPolicyConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-
-	if newConfig != oldConfig && *newConfig.NetworkPackStrategy != *oldConfig.NetworkPackStrategy {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("networkPackStrategy"), "field is immutable"))
-	}
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig, oldConfig, fldPath.Child("networkPackStrategy"))...)
 	return allErrs
 }
 
@@ -434,9 +423,7 @@ func validatePodSpecUpdate(newSpec, oldSpec *corev1.PodSpec, fldPath *field.Path
 	spec1.Tolerations, spec2.Tolerations = []corev1.Toleration{}, []corev1.Toleration{}
 	spec1.TerminationGracePeriodSeconds, spec2.TerminationGracePeriodSeconds = nil, nil
 
-	if !reflect.DeepEqual(spec1, spec2) {
-		allErrs = append(allErrs, field.Forbidden(fldPath, "not allowed to change immutable pod fields"))
-	}
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec1, spec2, fldPath)...)
 
 	return allErrs
 }


### PR DESCRIPTION
In general, I prefer specifying the defaults in the CRD itself, instead of a defaulting webhook defaulting these values. This PR attempts to fix a few places where this change was trivial.

* Move `+kubebuilder:default` annotation to the field definition from the type definition.

  * Defaultling only occurs on fields, thus moved the defaulting annotation to the field definition.

  * Remove the explicit defaulting in the defaulting webhook.

* Use `+kubebuilder` annotation to default the value of `PodGangTemplateSpec.SchedulingPolicyConfig`.

  * Default the value to `BestEffort` through the annotation, which will include the default value in the CRD for `PodGangSet`.

  * Remove the explicit defaulting in the defaulting webhook.

* Use `apivalidation.ValidateImmutableField()` where applicable.

* Change the type of `PodGangTemplateSpec.Cliques` to `[]PodCliqueTemplateSpec` from `[]*PodCliqueTemplateSpec`.