### PR TITLE
Add test and coverage targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,3 +58,26 @@ add-license-headers:
 .PHONY: generate-api-docs
 generate-api-docs: $(CRD_REF_DOCS)
 	@$(REPO_HACK_DIR)/generate-api-docs.sh
+
+# Runs unit tests for the entire codebase (all modules)
+.PHONY: test
+test:
+	@echo "> Running tests for operator"
+	@make --directory=operator test-unit
+	@echo "> Running tests for scheduler"
+	@make --directory=scheduler test-unit
+
+.PHONY: test-cover
+test-cover:
+	@echo "> Running tests with coverage for operator"
+	@make --directory=operator test-cover
+	@echo "> Running tests with coverage for scheduler"
+	@make --directory=scheduler test-cover
+
+# Generates HTML coverage reports for the entire codebase (all modules)
+.PHONY: cover-html
+cover-html:
+	@echo "> Generating HTML coverage report for operator"
+	@make --directory=operator cover-html
+	@echo "> Generating HTML coverage report for scheduler"
+	@make --directory=scheduler cover-html

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -76,6 +76,17 @@ add-license-headers: $(GO_ADD_LICENSE)
 test-unit:
 	@go test ./...
 
+# Run all unit tests with code coverage
+.PHONY: test-cover
+test-cover:
+	@go test ./... -coverprofile=coverage.out
+
+# Generate HTML coverage report
+.PHONY: cover-html
+cover-html: test-cover
+	@go tool cover -html=coverage.out -o coverage.html
+	@echo "Coverage report generated at coverage.html"
+
 # Make targets for local development and testing
 # -------------------------------------------------------------
 # Starts a local k8s cluster using kind.

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -57,6 +57,25 @@ format: $(GOIMPORTS_REVISER)
 add-license-headers: $(GO_ADD_LICENSE)
 	@$(REPO_HACK_DIR)/add-license-headers.sh
 
+# Make targets for tests
+# -------------------------------------------------------------
+
+# Run all unit tests
+.PHONY: test-unit
+test-unit:
+	@go test ./...
+
+# Run all unit tests with code coverage
+.PHONY: test-cover
+test-cover:
+	@go test ./... -coverprofile=coverage.out
+
+# Generate HTML coverage report
+.PHONY: cover-html
+cover-html: test-cover
+	@go tool cover -html=coverage.out -o coverage.html
+	@echo "Coverage report generated at coverage.html"
+
 # Make targets for local development and testing
 # -------------------------------------------------------------
 # Starts a local k8s cluster using kind.


### PR DESCRIPTION
This pull request introduces new Makefile targets to streamline testing and coverage reporting across multiple modules (`operator` and `scheduler`). The changes include adding commands to run unit tests, generate coverage reports, and produce HTML coverage summaries.

### Testing Enhancements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R61-R83): Added `test`, `test-cover`, and `cover-html` targets to run unit tests, execute tests with coverage, and generate HTML coverage reports for the entire codebase. These targets delegate to module-specific Makefiles.

### Module-Specific Testing Targets:

* [`operator/Makefile`](diffhunk://#diff-6973a61c21dd57b26f0452d3716fe9213974883a2fe1b216504bf63532cd1187R79-R89): Added `test-cover` and `cover-html` targets to run unit tests with coverage and generate HTML coverage reports specifically for the `operator` module.
* [`scheduler/Makefile`](diffhunk://#diff-8d4cb756eff4aa96732f3b1e2ebd3d876f19ed086a2741aafd9bb1139190e960R60-R78): Added `test-unit`, `test-cover`, and `cover-html` targets to run unit tests, execute tests with coverage, and generate HTML coverage reports specifically for the `scheduler` module.