### PR TITLE
Fix HPA selector labels for `PodClique`s created by `PodCliqueScalingGroup`s.

### DIFF
--- a/operator/internal/component/podcliquescalinggroup/podclique/podclique.go
+++ b/operator/internal/component/podcliquescalinggroup/podclique/podclique.go
@@ -355,7 +355,7 @@ func getPodCliqueSelectorLabels(pcsgObjectMeta metav1.ObjectMeta) map[string]str
 	return lo.Assign(
 		k8sutils.GetDefaultLabelsForPodGangSetManagedResources(*pgsName),
 		map[string]string{
-			grovecorev1alpha1.LabelComponentKey:          component.NamePodClique,
+			grovecorev1alpha1.LabelComponentKey:          component.NamePCSGPodClique,
 			grovecorev1alpha1.LabelPodCliqueScalingGroup: pcsgObjectMeta.Name,
 		},
 	)
@@ -365,7 +365,7 @@ func getLabels(pgsName string, pgsReplicaIndex int, pcsgName string, pcsgReplica
 	podGangName := componentutils.CreatePodGangNameForPCSG(pgsName, pgsReplicaIndex, pcsgName, pcsgReplicaIndex)
 	pclqComponentLabels := map[string]string{
 		grovecorev1alpha1.LabelAppNameKey:             pclqObjectKey.Name,
-		grovecorev1alpha1.LabelComponentKey:           component.NamePodClique,
+		grovecorev1alpha1.LabelComponentKey:           component.NamePCSGPodClique,
 		grovecorev1alpha1.LabelPodGangSetReplicaIndex: strconv.Itoa(pgsReplicaIndex),
 		grovecorev1alpha1.LabelPodCliqueScalingGroup:  pcsgName,
 		grovecorev1alpha1.LabelPodGangName:            podGangName,

--- a/operator/internal/component/podgangset/podclique/podclique.go
+++ b/operator/internal/component/podgangset/podclique/podclique.go
@@ -356,7 +356,7 @@ func getPodCliqueSelectorLabels(pgsObjectMeta metav1.ObjectMeta) map[string]stri
 	return lo.Assign(
 		k8sutils.GetDefaultLabelsForPodGangSetManagedResources(pgsObjectMeta.Name),
 		map[string]string{
-			grovecorev1alpha1.LabelComponentKey: component.NamePodClique,
+			grovecorev1alpha1.LabelComponentKey: component.NamePGSPodClique,
 		},
 	)
 }
@@ -365,7 +365,7 @@ func getLabels(pgsName string, pgsReplica int, pclqObjectKey client.ObjectKey, p
 	podGangName := grovecorev1alpha1.GeneratePodGangName(grovecorev1alpha1.ResourceNameReplica{Name: pgsName, Replica: pgsReplica}, nil)
 	pclqComponentLabels := map[string]string{
 		grovecorev1alpha1.LabelAppNameKey:             pclqObjectKey.Name,
-		grovecorev1alpha1.LabelComponentKey:           component.NamePodClique,
+		grovecorev1alpha1.LabelComponentKey:           component.NamePGSPodClique,
 		grovecorev1alpha1.LabelPodGangSetReplicaIndex: strconv.Itoa(pgsReplica),
 		grovecorev1alpha1.LabelPodGangName:            podGangName,
 	}

--- a/operator/internal/component/types.go
+++ b/operator/internal/component/types.go
@@ -41,8 +41,10 @@ const (
 // These component names will be set against grovecorev1alpha1.LabelComponentKey label key on
 // respective components.
 const (
-	// NamePodClique is the component name for a PodClique resource.
-	NamePodClique = "pgs-podclique"
+	// NamePGSPodClique is the component name for a PodClique resource handled by a PodGangSet.
+	NamePGSPodClique = "pgs-podclique"
+	// NamePCSGPodClique is the component name for a PodClique resource handled by a PodCliqueScalingGroup.
+	NamePCSGPodClique = "pcsg-podclique"
 	// NamePodGangHeadlessService is the component name for a Headless service for a Pod Gang.
 	NamePodGangHeadlessService = "pgs-headless-service"
 	// NamePodRole is the component name for a role that is associated to all Pods that are created for a PodGangSet.

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -73,7 +73,7 @@ func updateSelector(pgsName string, pclq *grovecorev1alpha1.PodClique) error {
 	labels := lo.Assign(
 		k8sutils.GetDefaultLabelsForPodGangSetManagedResources(pgsName),
 		map[string]string{
-			grovecorev1alpha1.LabelAppNameKey: pclq.Name,
+			grovecorev1alpha1.LabelPodCliqueName: pclq.Name,
 		},
 	)
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: labels})

--- a/operator/internal/controller/podcliquescalinggroup/reconciler.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciler.go
@@ -98,7 +98,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, pcsg *grovecorev1alpha
 	labels := lo.Assign(
 		k8sutils.GetDefaultLabelsForPodGangSetManagedResources(pgsName),
 		map[string]string{
-			grovecorev1alpha1.LabelAppNameKey: pcsg.Name,
+			grovecorev1alpha1.LabelPodCliqueScalingGroup: pcsg.Name,
 		},
 	)
 

--- a/operator/samples/simple/simple1.yaml
+++ b/operator/samples/simple/simple1.yaml
@@ -69,7 +69,7 @@ spec:
                   requests:
                     cpu: 10m
     podCliqueScalingGroups:
-      - name: pcsg
+      - name: sga
         cliqueNames:
           - pcb
           - pcc

--- a/operator/test/utils/pclq.go
+++ b/operator/test/utils/pclq.go
@@ -118,7 +118,7 @@ func createDefaultPodCliqueWithoutPodSpec(pgsName string, pgsUID types.UID, pclq
 func getDefaultLabels(pgsName, pclqName string) map[string]string {
 	pclqComponentLabels := map[string]string{
 		grovecorev1alpha1.LabelAppNameKey:   pclqName,
-		grovecorev1alpha1.LabelComponentKey: component.NamePodClique,
+		grovecorev1alpha1.LabelComponentKey: component.NamePGSPodClique,
 	}
 	return lo.Assign(
 		k8sutils.GetDefaultLabelsForPodGangSetManagedResources(pgsName),


### PR DESCRIPTION
* `HPA` now identifies `Pod`s to scale on `grove.io/podcliquescalinggroup`, and `grove.io/podclique` labels for `PodClique`s created by `PodCliqueScalingGroup` and `PodGangSet` respectively. This is done instead of  `app.kubernetes.io/name`, since the value of this label on `Pod`s is the `PodClique` name, and this can not be used for `PodClique`s created by `PodCliqueScalingGroup`s.

* The `app.kubernetes.io/component` label's value is now either `pgs-podclique` if the `PodClique` is created by `PodGangSet`, or `pcsg-podclique` if the `PodClique` is created by `PodCliqueScalingGroup`.