### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,58 @@
+name: Build and Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.24.5"
+      - name: test-unit
+        run: make test-unit
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.24.5"
+      - name: build-operator
+        run: make --directory=operator build-operator
+      - name: build-initc
+        run: make --directory=operator build-initc
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.24.5"
+      - name: lint
+        run: make lint
+      - name: generate
+        run: make generate
+      - name: license
+        run: make add-license-headers
+      - name: format
+        run: make format
+      - name: api-docs
+        run: make generate-api-docs
+      - name: fail if git tree is dirty
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "ERROR: Git tree is dirty after running the check step."
+            echo "Please check the diff to identify the step that dirtied the tree."
+            git status
+            git diff
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,13 @@ go.work.sum
 # env file
 .env
 
+# developer files
+dev
+
 # code editor ignores
 .vscode
 .idea
+.zed
 .DS_Store
 
 # hack tools binaries

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,11 @@ REPO_HACK_DIR       := $(REPO_ROOT)/hack
 
 include $(REPO_HACK_DIR)/tools.mk
 
-# Lints the entire codebase (all modules) using GOLANGCI_LINT.
+# Lints the entire codebase using GOLANGCI_LINT.
 .PHONY: lint
 lint:
+	@echo "> Linting operator/api"
+	@make --directory=operator/api lint
 	@echo "> Linting operator"
 	@make --directory=operator lint
 	@echo "> Linting scheduler/api"
@@ -44,15 +46,10 @@ generate:
 	@echo "> Generating code for scheduler api"
 	@make --directory=scheduler/api generate
 
-# Add license headers to all files (all modules)
+# Add license headers to all files
 .PHONY: add-license-headers
-add-license-headers:
-	@echo "> Adding license headers to operator"
-	@make --directory=operator add-license-headers
-	@echo "> Adding license headers to scheduler/api"
-	@make --directory=scheduler/api add-license-headers
-	@echo "> Adding license headers to scheduler"
-	@make --directory=scheduler add-license-headers
+add-license-headers: $(GO_ADD_LICENSE)
+	@$(REPO_HACK_DIR)/add-license-headers.sh
 
 # Generates API documentation for Grove Operator and Scheduler APIs
 .PHONY: generate-api-docs
@@ -60,8 +57,8 @@ generate-api-docs: $(CRD_REF_DOCS)
 	@$(REPO_HACK_DIR)/generate-api-docs.sh
 
 # Runs unit tests for the entire codebase (all modules)
-.PHONY: test
-test:
+.PHONY: test-unit
+test-unit:
 	@echo "> Running tests for operator"
 	@make --directory=operator test-unit
 	@echo "> Running tests for scheduler"

--- a/hack/generate-api-docs.sh
+++ b/hack/generate-api-docs.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+# /*
+# Copyright 2025 The Grove Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
 
 set -o errexit
 set -o nounset

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # builder
-FROM --platform=$BUILDPLATFORM golang:1.24.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.5 AS builder
 WORKDIR /go/src/github.com/NVIDIA/grove
 COPY ../. .
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -61,12 +61,7 @@ lint: $(GOLANGCI_LINT)
 # Formats the codebase
 .PHONY: format
 format: $(GOIMPORTS_REVISER)
-	@$(REPO_HACK_DIR)/format.sh ./api/ ./internal/ ./cmd/
-
-# Add license headers to all files
-.PHONY: add-license-headers
-add-license-headers: $(GO_ADD_LICENSE)
-	@$(REPO_HACK_DIR)/add-license-headers.sh
+	@$(REPO_HACK_DIR)/format.sh ./api/ ./cmd/ ./initc/ ./internal/  ./test/
 
 # Make targets for tests
 # -------------------------------------------------------------

--- a/operator/api/Makefile
+++ b/operator/api/Makefile
@@ -31,13 +31,3 @@ generate: $(CONTROLLER_GEN)
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
 	@$(GOLANGCI_LINT) run -c $(REPO_ROOT)/.golangci.yaml ./...
-
-# Formats the codebase
-.PHONY: format
-format: $(GOIMPORTS_REVISER)
-	@$(REPO_HACK_DIR)/format.sh ./api/
-
-# Add license headers to all files
-.PHONY: add-license-headers
-add-license-headers: $(GO_ADD_LICENSE)
-	@$(REPO_HACK_DIR)/add-license-headers.sh

--- a/operator/initc/internal/wait.go
+++ b/operator/initc/internal/wait.go
@@ -26,8 +26,8 @@ import (
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	groveclientset "github.com/NVIDIA/grove/operator/client/clientset/versioned"
 	groveinformers "github.com/NVIDIA/grove/operator/client/informers/externalversions"
-	"github.com/go-logr/logr"
 
+	"github.com/go-logr/logr"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )

--- a/operator/internal/component/podcliquescalinggroup/podclique/podclique.go
+++ b/operator/internal/component/podcliquescalinggroup/podclique/podclique.go
@@ -138,7 +138,6 @@ func (r _resource) Sync(ctx context.Context, logger logr.Logger, pcsg *grovecore
 			}
 			tasks = append(tasks, createOrUpdateTask)
 		}
-
 	}
 	if runResult := utils.RunConcurrently(ctx, logger, tasks); runResult.HasErrors() {
 		return groveerr.WrapError(runResult.GetAggregatedError(),

--- a/operator/internal/component/podcliquescalinggroup/registry.go
+++ b/operator/internal/component/podcliquescalinggroup/registry.go
@@ -26,7 +26,7 @@ import (
 )
 
 // CreateOperatorRegistry initializes the operator registry for the PodCliqueScalingGroup reconciler.
-func CreateOperatorRegistry(mgr manager.Manager, eventRecorder record.EventRecorder) component.OperatorRegistry[v1alpha1.PodCliqueScalingGroup] {
+func CreateOperatorRegistry(mgr manager.Manager, _ record.EventRecorder) component.OperatorRegistry[v1alpha1.PodCliqueScalingGroup] {
 	reg := component.NewOperatorRegistry[v1alpha1.PodCliqueScalingGroup]()
 	reg.Register(component.KindPodClique, podclique.New(mgr.GetClient(), mgr.GetScheme()))
 	return reg

--- a/operator/internal/component/podgangset/podclique/podclique.go
+++ b/operator/internal/component/podgangset/podclique/podclique.go
@@ -19,13 +19,13 @@ package podclique
 import (
 	"context"
 	"fmt"
-	componentutils "github.com/NVIDIA/grove/operator/internal/component/utils"
 	"slices"
 	"strconv"
 	"strings"
 
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"
+	componentutils "github.com/NVIDIA/grove/operator/internal/component/utils"
 	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
 	"github.com/NVIDIA/grove/operator/internal/utils"
 	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
@@ -217,11 +217,7 @@ func (r _resource) Delete(ctx context.Context, logger logr.Logger, pgsObjectMeta
 			Name: "DeletePodClique-" + pclqName,
 			Fn: func(ctx context.Context) error {
 				if err := client.IgnoreNotFound(r.client.Delete(ctx, emptyPodClique(pclqObjectKey))); err != nil {
-					return groveerr.WrapError(err,
-						errDeletePodClique,
-						component.OperationDelete,
-						fmt.Sprintf("Failed to delete PodClique: %v for PodGangSet: %v", pclqObjectKey, k8sutils.GetObjectKeyFromObjectMeta(pgsObjectMeta)),
-					)
+					return fmt.Errorf("failed to delete PodClique: %v for PodGangSet: %v with error: %w", pclqObjectKey, k8sutils.GetObjectKeyFromObjectMeta(pgsObjectMeta), err)
 				}
 				return nil
 			},

--- a/operator/internal/component/podgangset/podclique/podclique_test.go
+++ b/operator/internal/component/podgangset/podclique/podclique_test.go
@@ -122,7 +122,7 @@ func TestDelete(t *testing.T) {
 	testCases := []struct {
 		description           string
 		numExistingPodCliques int
-		deleteAllOfError      *apierrors.StatusError
+		deleteError           *apierrors.StatusError
 		expectedError         *groveerr.GroveError
 	}{
 		{
@@ -138,7 +138,7 @@ func TestDelete(t *testing.T) {
 		{
 			description:           "error when deleting existing PodCliques",
 			numExistingPodCliques: 2,
-			deleteAllOfError:      testutils.TestAPIInternalErr,
+			deleteError:           testutils.TestAPIInternalErr,
 			expectedError: &groveerr.GroveError{
 				Code:      errDeletePodClique,
 				Cause:     testutils.TestAPIInternalErr,
@@ -158,7 +158,7 @@ func TestDelete(t *testing.T) {
 			t.Parallel()
 			existingPodCliques := createDefaultPodCliques(pgsObjMeta, "howl", tc.numExistingPodCliques)
 			// Create a fake client with PodCliques
-			cl := testutils.CreateFakeClientForObjectsMatchingLabels(tc.deleteAllOfError, nil, testPGSNamespace, grovecorev1alpha1.SchemeGroupVersion.WithKind("PodClique"), getPodCliqueSelectorLabels(pgsObjMeta), existingPodCliques...)
+			cl := testutils.CreateFakeClientForObjectsMatchingLabels(tc.deleteError, nil, testPGSNamespace, grovecorev1alpha1.SchemeGroupVersion.WithKind("PodClique"), getPodCliqueSelectorLabels(pgsObjMeta), existingPodCliques...)
 			operator := New(cl, groveclientscheme.Scheme)
 			err := operator.Delete(context.Background(), logr.Discard(), pgsObjMeta)
 			if tc.expectedError != nil {
@@ -180,8 +180,8 @@ func getExistingPodCliques(t *testing.T, cl client.Client, pgsObjMeta metav1.Obj
 
 func createDefaultPodCliques(pgsObjMeta metav1.ObjectMeta, pclqNamePrefix string, numPodCliques int) []client.Object {
 	podCliqueNames := make([]client.Object, 0, numPodCliques)
-	for i := 0; i < numPodCliques; i++ {
-		pclq := testutils.NewPodCliqueBuilder(pgsObjMeta.Name, types.UID(uuid.NewString()), fmt.Sprintf("%s-%d", pclqNamePrefix, i), pgsObjMeta.Namespace, 0).
+	for i := range numPodCliques {
+		pclq := testutils.NewPodCliqueBuilder(pgsObjMeta.Name, pgsObjMeta.GetUID(), fmt.Sprintf("%s-%d", pclqNamePrefix, i), pgsObjMeta.Namespace, 0).
 			WithLabels(getPodCliqueSelectorLabels(pgsObjMeta)).
 			Build()
 		podCliqueNames = append(podCliqueNames, pclq)

--- a/operator/internal/component/utils/podgang.go
+++ b/operator/internal/component/utils/podgang.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"
 	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"

--- a/operator/internal/component/utils/podgangset.go
+++ b/operator/internal/component/utils/podgangset.go
@@ -1,3 +1,19 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
 package utils
 
 import (

--- a/operator/internal/component/utils/podgangset.go
+++ b/operator/internal/component/utils/podgangset.go
@@ -3,10 +3,11 @@ package utils
 import (
 	"context"
 	"fmt"
-	"github.com/samber/lo"
 
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
+
+	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/operator/internal/controller/podclique/reconciler.go
+++ b/operator/internal/controller/podclique/reconciler.go
@@ -18,6 +18,7 @@ package podclique
 
 import (
 	"context"
+
 	configv1alpha1 "github.com/NVIDIA/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -19,6 +19,7 @@ package podclique
 import (
 	"context"
 	"fmt"
+
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	componentutils "github.com/NVIDIA/grove/operator/internal/component/utils"
 	ctrlcommon "github.com/NVIDIA/grove/operator/internal/controller/common"

--- a/operator/internal/controller/podcliquescalinggroup/reconciledelete.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciledelete.go
@@ -1,3 +1,19 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
 package podcliquescalinggroup
 
 import (

--- a/operator/internal/controller/podcliquescalinggroup/reconciler.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciler.go
@@ -18,7 +18,6 @@ package podcliquescalinggroup
 
 import (
 	"context"
-	"errors"
 
 	groveconfigv1alpha1 "github.com/NVIDIA/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
@@ -36,8 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllogger "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-var errUndefinedPodCliqueName = errors.New("podclique is not defined in PodGangSet")
 
 // Reconciler reconciles PodCliqueScalingGroup objects.
 type Reconciler struct {

--- a/operator/internal/controller/podcliquescalinggroup/reconciler.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciler.go
@@ -27,6 +27,7 @@ import (
 	ctrlcommon "github.com/NVIDIA/grove/operator/internal/controller/common"
 	ctrlutils "github.com/NVIDIA/grove/operator/internal/controller/utils"
 	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
+
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"

--- a/operator/internal/controller/podcliquescalinggroup/reconcilespec.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilespec.go
@@ -1,3 +1,19 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
 package podcliquescalinggroup
 
 import (

--- a/operator/internal/controller/podcliquescalinggroup/reconcilespec.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilespec.go
@@ -19,16 +19,13 @@ package podcliquescalinggroup
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"
 	ctrlcommon "github.com/NVIDIA/grove/operator/internal/controller/common"
 	ctrlutils "github.com/NVIDIA/grove/operator/internal/controller/utils"
-	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
 
 	"github.com/go-logr/logr"
-	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -85,55 +82,6 @@ func (r *Reconciler) syncPodCliqueScalingGroupResources(ctx context.Context, log
 			}
 			logger.Error(err, "failed to sync PodGangSet resources", "kind", kind)
 			return ctrlcommon.ReconcileWithErrors("error syncing managed resources", fmt.Errorf("failed to sync %s: %w", kind, err))
-		}
-	}
-	return ctrlcommon.ContinueReconcile()
-}
-
-func (r *Reconciler) updatePodCliques(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) ctrlcommon.ReconcileStepResult {
-	// Get the owner PodGangSet for the PodCliqueScalingGroup
-	pgs := &grovecorev1alpha1.PodGangSet{}
-	pgsObjectKey := client.ObjectKey{
-		Namespace: pcsg.Namespace,
-		Name:      k8sutils.GetFirstOwnerName(pcsg.ObjectMeta),
-	}
-	if result := ctrlutils.GetPodGangSet(ctx, r.client, logger, pgsObjectKey, pgs); ctrlcommon.ShortCircuitReconcileFlow(result) {
-		return result
-	}
-
-	for _, fullyQualifiedCliqueName := range pcsg.Spec.CliqueNames {
-		pclqObjectKey := client.ObjectKey{
-			Namespace: pcsg.Namespace,
-			Name:      fullyQualifiedCliqueName,
-		}
-		matchingPCLQTemplateSpec, ok := lo.Find(pgs.Spec.Template.Cliques, func(pclqTemplateSpec *grovecorev1alpha1.PodCliqueTemplateSpec) bool {
-			return strings.HasSuffix(fullyQualifiedCliqueName, pclqTemplateSpec.Name)
-		})
-		if !ok {
-			logger.Error(errUndefinedPodCliqueName, "podclique is not defined in PodGangSet, will skip updating podclique replicas", "pclqObjectKey", pclqObjectKey, "podGangSetObjectKey", pgsObjectKey)
-			return ctrlcommon.RecordErrorAndDoNotRequeue(fmt.Sprintf("podclique %s is not defined in PodGangSet %s", fullyQualifiedCliqueName, pgsObjectKey), errUndefinedPodCliqueName)
-		}
-		if result := r.updatePodCliqueReplicas(ctx, logger, pcsg, matchingPCLQTemplateSpec, pclqObjectKey); ctrlcommon.ShortCircuitReconcileFlow(result) {
-			return result
-		}
-	}
-
-	return ctrlcommon.ContinueReconcile()
-}
-
-func (r *Reconciler) updatePodCliqueReplicas(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pclqTemplateSpec *grovecorev1alpha1.PodCliqueTemplateSpec, pclqObjectKey client.ObjectKey) ctrlcommon.ReconcileStepResult {
-	pclq := &grovecorev1alpha1.PodClique{}
-	if result := ctrlutils.GetPodClique(ctx, r.client, logger, pclqObjectKey, pclq, false); ctrlcommon.ShortCircuitReconcileFlow(result) {
-		return result
-	}
-	// update the spec
-	expectedReplicas := pcsg.Spec.Replicas * pclqTemplateSpec.Spec.Replicas
-	if expectedReplicas != pclq.Spec.Replicas {
-		logger.Info("Updating PCLQ replicas due to change in PCSG replicas", "pcsgReplicas", pcsg.Spec.Replicas, "expectedReplicasForPCLQ", expectedReplicas)
-		patch := client.MergeFrom(pclq.DeepCopy())
-		pclq.Spec.Replicas = expectedReplicas
-		if err := r.client.Patch(ctx, pclq, patch); err != nil {
-			return ctrlcommon.ReconcileWithErrors("error patching PodClique replicas", err)
 		}
 	}
 	return ctrlcommon.ContinueReconcile()

--- a/operator/internal/controller/podcliquescalinggroup/reconcilespec.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilespec.go
@@ -3,16 +3,18 @@ package podcliquescalinggroup
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"
 	ctrlcommon "github.com/NVIDIA/grove/operator/internal/controller/common"
 	ctrlutils "github.com/NVIDIA/grove/operator/internal/controller/utils"
 	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
+
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
 )
 
 func (r *Reconciler) reconcileSpec(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) ctrlcommon.ReconcileStepResult {

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -1,1 +1,17 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
 package podcliquescalinggroup

--- a/operator/internal/controller/podcliquescalinggroup/register.go
+++ b/operator/internal/controller/podcliquescalinggroup/register.go
@@ -18,8 +18,10 @@ package podcliquescalinggroup
 
 import (
 	"context"
+
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	ctrlutils "github.com/NVIDIA/grove/operator/internal/controller/utils"
+
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"

--- a/operator/internal/controller/podgangset/reconciler.go
+++ b/operator/internal/controller/podgangset/reconciler.go
@@ -18,6 +18,7 @@ package podgangset
 
 import (
 	"context"
+
 	configv1alpha1 "github.com/NVIDIA/grove/operator/api/config/v1alpha1"
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"

--- a/operator/internal/controller/utils/reconciler.go
+++ b/operator/internal/controller/utils/reconciler.go
@@ -19,17 +19,17 @@ package utils
 import (
 	"context"
 	"errors"
-	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 
 	"github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"
 	grovectrl "github.com/NVIDIA/grove/operator/internal/controller/common"
 	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
+	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/operator/internal/webhook/admission/pgs/defaulting/podgangset_test.go
+++ b/operator/internal/webhook/admission/pgs/defaulting/podgangset_test.go
@@ -47,6 +47,7 @@ func TestDefaultPodGangSet(t *testing.T) {
 							MinReplicas: ptr.To(int32(2)),
 							MaxReplicas: 3,
 						},
+						MinAvailable: ptr.To[int32](2),
 					},
 				}},
 				HeadlessServiceConfig: &grovecorev1alpha1.HeadlessServiceConfig{

--- a/operator/internal/webhook/admission/pgs/validation/util.go
+++ b/operator/internal/webhook/admission/pgs/validation/util.go
@@ -18,10 +18,10 @@ package validation
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/NVIDIA/grove/operator/internal/utils"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )

--- a/operator/test/utils/client.go
+++ b/operator/test/utils/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	groveclientscheme "github.com/NVIDIA/grove/operator/internal/client"
+
 	"github.com/samber/lo"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/operator/test/utils/client.go
+++ b/operator/test/utils/client.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"context"
+
 	groveclientscheme "github.com/NVIDIA/grove/operator/internal/client"
 	"github.com/samber/lo"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -93,14 +94,16 @@ func CreateFakeClientForObjects(getErr, createErr, patchErr, deleteErr *apierror
 // CreateFakeClientForObjectsMatchingLabels creates a fake client.Client with initial set of existing objects
 // along with any expected list and/or deleteAll errors for objects matching the given matching labels for the given GVK.
 // If the matchingLabels is nil or empty then the deleteAll/list error will be recorded for all objects matching the GVK in the given namespace.
-func CreateFakeClientForObjectsMatchingLabels(deleteAllErr, listErr *apierrors.StatusError, namespace string, targetObjectsGVK schema.GroupVersionKind, matchingLabels map[string]string, existingObjects ...client.Object) client.Client {
+func CreateFakeClientForObjectsMatchingLabels(deleteErr, listErr *apierrors.StatusError, namespace string, targetObjectsGVK schema.GroupVersionKind, matchingLabels map[string]string, existingObjects ...client.Object) client.Client {
 	clientBuilder := NewTestClientBuilder()
-	if len(existingObjects) > 0 {
-		clientBuilder.WithObjects(existingObjects...)
+	for _, existingObject := range existingObjects {
+		// Errors recorded for individual object delete
+		clientBuilder.WithObjects(existingObject).
+			RecordErrorForObjectsMatchingLabels(ClientMethodDelete, client.ObjectKeyFromObject(existingObject), targetObjectsGVK, matchingLabels, deleteErr)
 	}
 	return clientBuilder.
-		RecordErrorForObjectsMatchingLabels(ClientMethodList, namespace, targetObjectsGVK, matchingLabels, listErr).
-		RecordErrorForObjectsMatchingLabels(ClientMethodDeleteAll, namespace, targetObjectsGVK, matchingLabels, deleteAllErr).
+		RecordErrorForObjectsMatchingLabels(ClientMethodList, client.ObjectKey{Namespace: namespace}, targetObjectsGVK, matchingLabels, listErr).
+		RecordErrorForObjectsMatchingLabels(ClientMethodDelete, client.ObjectKey{Namespace: namespace}, targetObjectsGVK, matchingLabels, deleteErr).
 		Build()
 }
 
@@ -145,13 +148,13 @@ func (b *TestClientBuilder) RecordErrorForObjects(method ClientMethod, err *apie
 }
 
 // RecordErrorForObjectsMatchingLabels records an error for a specific client.Client method and object keys matching the given labels for a given GVK.
-func (b *TestClientBuilder) RecordErrorForObjectsMatchingLabels(method ClientMethod, namespace string, targetObjectsGVK schema.GroupVersionKind, matchingLabels map[string]string, err *apierrors.StatusError) *TestClientBuilder {
+func (b *TestClientBuilder) RecordErrorForObjectsMatchingLabels(method ClientMethod, objectKey client.ObjectKey, targetObjectsGVK schema.GroupVersionKind, matchingLabels map[string]string, err *apierrors.StatusError) *TestClientBuilder {
 	if err == nil {
 		return b
 	}
 	b.errorRecords = append(b.errorRecords, errorRecord{
 		method:      method,
-		objectKey:   client.ObjectKey{Namespace: namespace},
+		objectKey:   objectKey,
 		resourceGVK: targetObjectsGVK,
 		labels:      matchingLabels,
 		err:         err,

--- a/operator/test/utils/errors.go
+++ b/operator/test/utils/errors.go
@@ -18,10 +18,12 @@ package utils
 
 import (
 	"errors"
+	"testing"
+
 	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
+
 	"github.com/stretchr/testify/assert"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"testing"
 )
 
 var (

--- a/operator/test/utils/pclq.go
+++ b/operator/test/utils/pclq.go
@@ -20,6 +20,7 @@ import (
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"
 	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
+
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/operator/test/utils/pgs.go
+++ b/operator/test/utils/pgs.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -1,5 +1,5 @@
 # builder
-FROM --platform=$BUILDPLATFORM golang:1.24.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.5 AS builder
 WORKDIR /go/src/github.com/NVIDIA/grove
 COPY ../. .
 

--- a/scheduler/Makefile
+++ b/scheduler/Makefile
@@ -50,12 +50,8 @@ lint: $(GOLANGCI_LINT)
 # Formats the codebase
 .PHONY: format
 format: $(GOIMPORTS_REVISER)
-	@$(REPO_HACK_DIR)/format.sh  ./api/ ./cmd/ ./internal/ ./plugins/
+	@$(REPO_HACK_DIR)/format.sh  ./api/ ./client/ ./cmd/ ./internal/ ./plugins/
 
-# Add license headers to all files
-.PHONY: add-license-headers
-add-license-headers: $(GO_ADD_LICENSE)
-	@$(REPO_HACK_DIR)/add-license-headers.sh
 
 # Make targets for tests
 # -------------------------------------------------------------

--- a/scheduler/api/Makefile
+++ b/scheduler/api/Makefile
@@ -31,13 +31,3 @@ generate: $(CONTROLLER_GEN)
 .PHONY: lint
 lint: $(GOLANGCI_LINT)
 	@$(GOLANGCI_LINT) run -c $(REPO_ROOT)/.golangci.yaml ./...
-
-# Formats the codebase
-.PHONY: format
-format: $(GOIMPORTS_REVISER)
-	@$(REPO_HACK_DIR)/format.sh ./api/
-
-# Add license headers to all files
-.PHONY: add-license-headers
-add-license-headers: $(GO_ADD_LICENSE)
-	@$(REPO_HACK_DIR)/add-license-headers.sh


### PR DESCRIPTION
We now use GitHub Actions for the following:

* Build the `operator` and `initc` binaries.
* Run all unit tests.
* Generate CRDs and clients.
* Generate API docs.
* Run the formatter.
* Run the linter.
* Add license headers.

If the git tree is dirtied by any of the above steps, then the workflow fails. The PR author will have to commit changes in manually to ensure the workflow passes.

****

The following are still pending:

* Workflow to build docker images for `operator` and `initc`.
* Workflow to publish these docker images to a container registry.
* Workflow to trigger and tag a release.

****

This PR also removes dead code, and cleans up the Makefiles.