### PR TITLE
Add validation target to Makefile and update build-and-test.yaml

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -37,22 +37,5 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.24.5"
-      - name: lint
-        run: make lint
-      - name: generate
-        run: make generate
-      - name: license
-        run: make add-license-headers
-      - name: format
-        run: make format
-      - name: api-docs
-        run: make generate-api-docs
-      - name: fail if git tree is dirty
-        run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            echo "ERROR: Git tree is dirty after running the check step."
-            echo "Please check the diff to identify the step that dirtied the tree."
-            git status
-            git diff
-            exit 1
-          fi
+      - name: validate
+        run: make validate

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,19 @@ REPO_HACK_DIR       := $(REPO_ROOT)/hack
 
 include $(REPO_HACK_DIR)/tools.mk
 
+# Validates the entire codebase by running lints, tests, and checking for uncommitted changes
+.PHONY: validate
+validate: lint test-unit generate add-license-headers format generate-api-docs
+	@echo "> Checking for uncommitted changes"
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "ERROR: Git tree is dirty after running validation steps."; \
+		echo "Please check the diff to identify the step that dirtied the tree."; \
+		git status; \
+		git diff; \
+		exit 1; \
+	fi
+	@echo "> Validation complete"
+
 .PHONY: build
 build:
 	@echo "> Building Grove Operator"


### PR DESCRIPTION
This pull request simplifies the CI workflow by replacing multiple individual validation steps with a single `make validate` command and introduces a corresponding `validate` target in the `Makefile`. The key changes are as follows:

### Workflow Simplification:
* [`.github/workflows/build-and-test.yaml`](diffhunk://#diff-a551b322da0f9fe92abd1ec41e43c58dc5d138c0000430395e66f0c581387cd2L40-R41): Replaced multiple separate steps (`lint`, `generate`, `license`, `format`, `api-docs`, and a git tree check) with a single `validate` step that runs `make validate`.

### Makefile Enhancements:
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R21-R33): Added a new `validate` target that consolidates linting, testing, code generation, license header addition, formatting, API docs generation, and a check for uncommitted changes into one command.