### PR TITLE
Introduce the expectations pattern for PodClique controller and fix gang termination post minAvailable/Replicas changes to PCSG

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -37,5 +37,5 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.24.5"
-      - name: validate
-        run: make validate
+      - name: check
+        run: make check

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ REPO_HACK_DIR       := $(REPO_ROOT)/hack
 
 include $(REPO_HACK_DIR)/tools.mk
 
-# Validates the entire codebase by running lints, tests, and checking for uncommitted changes
-.PHONY: validate
-validate: lint test-unit generate add-license-headers format generate-api-docs
+# Checks the entire codebase by linting and formatting the code base, and checking for uncommitted changes
+.PHONY: check
+validate: generate add-license-headers format generate-api-docs lint
 	@echo "> Checking for uncommitted changes"
 	@if [ -n "$$(git status --porcelain)" ]; then \
 		echo "ERROR: Git tree is dirty after running validation steps."; \
@@ -29,7 +29,7 @@ validate: lint test-unit generate add-license-headers format generate-api-docs
 		git diff; \
 		exit 1; \
 	fi
-	@echo "> Validation complete"
+	@echo "> Check complete"
 
 .PHONY: build
 build:

--- a/docs/api-reference/operator-api.md
+++ b/docs/api-reference/operator-api.md
@@ -120,7 +120,7 @@ _Appears in:_
 | `type` _[LastOperationType](#lastoperationtype)_ | Type is the type of the last operation. |  |  |
 | `state` _[LastOperationState](#lastoperationstate)_ | State is the state of the last operation. |  |  |
 | `description` _string_ | Description is a human-readable description of the last operation. |  |  |
-| `lastTransitionTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#time-v1-meta)_ | LastUpdateTime is the time at which the last operation was updated. |  |  |
+| `lastUpdateTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#time-v1-meta)_ | LastUpdateTime is the time at which the last operation was updated. |  |  |
 
 
 #### LastOperationState
@@ -315,7 +315,6 @@ _Appears in:_
 | `lastErrors` _[LastError](#lasterror) array_ | LastErrors captures the last errors observed by the controller when reconciling the PodClique. |  |  |
 | `replicas` _integer_ | Replicas is the total number of non-terminated Pods targeted by this PodClique. |  |  |
 | `readyReplicas` _integer_ | ReadyReplicas is the number of ready Pods targeted by this PodClique. |  |  |
-| `updatedReplicas` _integer_ | UpdatedReplicas is the number of Pods that have been updated and are at the desired revision of the PodClique. |  |  |
 | `scheduleGatedReplicas` _integer_ | ScheduleGatedReplicas is the number of Pods that have been created with one or more scheduling gate(s) set.<br />Sum of ReadyReplicas and ScheduleGatedReplicas will always be <= Replicas. |  |  |
 | `hpaPodSelector` _string_ | Selector is the label selector that determines which pods are part of the PodClique.<br />PodClique is a unit of scale and this selector is used by HPA to scale the PodClique based on metrics captured for the pods that match this selector. |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#condition-v1-meta) array_ | Conditions represents the latest available observations of the clique by its controller. |  |  |

--- a/operator/api/core/v1alpha1/constants.go
+++ b/operator/api/core/v1alpha1/constants.go
@@ -98,4 +98,25 @@ const (
 const (
 	// ConditionTypeMinAvailableBreached indicates that the minimum number of ready pods in the PodClique are below the threshold defined in the PodCliqueSpec.MinAvailable threshold.
 	ConditionTypeMinAvailableBreached = "MinAvailableBreached"
+	// ConditionTypePodCliqueScheduled indicates that the PodClique has been successfully scheduled.
+	// This condition is set to true when number of scheduled pods in the PodClique is greater than or equal to PodCliqueSpec.MinAvailable.
+	ConditionTypePodCliqueScheduled = "PodCliqueScheduled"
+)
+
+// Constants for Condition Reasons
+const (
+	// ConditionReasonInsufficientReadyPods indicates that the number of ready pods in the PodClique is below the threshold defined in the PodCliqueSpec.MinAvailable threshold.
+	ConditionReasonInsufficientReadyPods = "InsufficientReadyPods"
+	// ConditionReasonSufficientReadyPods indicates that the number of ready pods in the PodClique is above the threshold defined in the PodCliqueSpec.MinAvailable threshold.
+	ConditionReasonSufficientReadyPods = "SufficientReadyPods"
+	// ConditionReasonInsufficientScheduledPods indicates that the number of scheduled pods in the PodClique is below the threshold defined in the PodCliqueSpec.MinAvailable threshold.
+	ConditionReasonInsufficientScheduledPods = "InsufficientScheduledPods"
+	// ConditionReasonSufficientScheduledPods indicates that the number of scheduled pods in the PodClique greater or equal to PodCliqueSpec.MinAvailable.
+	ConditionReasonSufficientScheduledPods = "SufficientScheduledPods"
+	// ConditionReasonInsufficientScheduledPCSGReplicas indicates that the number of scheduled replicas in the PodCliqueScalingGroup is below the PodCliqueScalingGroupSpec.MinAvailable.
+	ConditionReasonInsufficientScheduledPCSGReplicas = "InsufficientScheduledPodCliqueScalingGroupReplicas"
+	// ConditionReasonInsufficientReadyPCSGReplicas indicates that the number of ready replicas in the PodCliqueScalingGroup is below the PodCliqueScalingGroupSpec.MinAvailable.
+	ConditionReasonInsufficientReadyPCSGReplicas = "InsufficientReadyPodCliqueScalingGroupReplicas"
+	// ConditionReasonSufficientReadyPCSGReplicas indicates that the number of ready replicas in the PodCliqueScalingGroup is greater than or equal to the PodCliqueScalingGroupSpec.MinAvailable.
+	ConditionReasonSufficientReadyPCSGReplicas = "SufficientReadyPodCliqueScalingGroupReplicas"
 )

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
@@ -8689,7 +8689,7 @@ spec:
                 type: integer
               scheduledReplicas:
                 description: ScheduledReplicas is the number of Pods that have been
-                  scheduled by the scheduler.
+                  scheduled by the kube-scheduler.
                 format: int32
                 type: integer
               updatedReplicas:

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
@@ -8687,6 +8687,11 @@ spec:
                   Sum of ReadyReplicas and ScheduleGatedReplicas will always be <= Replicas.
                 format: int32
                 type: integer
+              scheduledReplicas:
+                description: ScheduledReplicas is the number of Pods that have been
+                  scheduled by the scheduler.
+                format: int32
+                type: integer
               updatedReplicas:
                 description: UpdatedReplicas is the number of Pods that have been
                   updated and are at the desired revision of the PodClique.

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliques.yaml
@@ -8649,7 +8649,7 @@ spec:
                     description: Description is a human-readable description of the
                       last operation.
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     description: LastUpdateTime is the time at which the last operation
                       was updated.
                     format: date-time
@@ -8662,7 +8662,7 @@ spec:
                     type: string
                 required:
                 - description
-                - lastTransitionTime
+                - lastUpdateTime
                 - state
                 - type
                 type: object

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
@@ -195,6 +195,13 @@ spec:
                 description: Replicas is the observed number of replicas for the PodCliqueScalingGroup.
                 format: int32
                 type: integer
+              scheduledReplicas:
+                description: |-
+                  ScheduledReplicas is the number of replicas that are scheduled for the PodCliqueScalingGroup.
+                  A replica of PodCliqueScalingGroup is considered "scheduled" when at least MinAvailable number
+                  of pods in each constituent PodClique has been scheduled.
+                format: int32
+                type: integer
               selector:
                 description: Selector is the selector used to identify the pods that
                   belong to this scaling group.

--- a/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podcliquescalinggroups.yaml
@@ -169,7 +169,7 @@ spec:
                     description: Description is a human-readable description of the
                       last operation.
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     description: LastUpdateTime is the time at which the last operation
                       was updated.
                     format: date-time
@@ -182,7 +182,7 @@ spec:
                     type: string
                 required:
                 - description
-                - lastTransitionTime
+                - lastUpdateTime
                 - state
                 - type
                 type: object

--- a/operator/api/core/v1alpha1/crds/grove.io_podgangsets.yaml
+++ b/operator/api/core/v1alpha1/crds/grove.io_podgangsets.yaml
@@ -9693,7 +9693,7 @@ spec:
                     description: Description is a human-readable description of the
                       last operation.
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     description: LastUpdateTime is the time at which the last operation
                       was updated.
                     format: date-time
@@ -9706,7 +9706,7 @@ spec:
                     type: string
                 required:
                 - description
-                - lastTransitionTime
+                - lastUpdateTime
                 - state
                 - type
                 type: object

--- a/operator/api/core/v1alpha1/podclique.go
+++ b/operator/api/core/v1alpha1/podclique.go
@@ -117,6 +117,8 @@ type PodCliqueStatus struct {
 	// ScheduleGatedReplicas is the number of Pods that have been created with one or more scheduling gate(s) set.
 	// Sum of ReadyReplicas and ScheduleGatedReplicas will always be <= Replicas.
 	ScheduleGatedReplicas int32 `json:"scheduleGatedReplicas,omitempty"`
+	// ScheduledReplicas is the number of Pods that have been scheduled by the kube-scheduler.
+	ScheduledReplicas int32 `json:"scheduledReplicas,omitempty"`
 	// Selector is the label selector that determines which pods are part of the PodClique.
 	// PodClique is a unit of scale and this selector is used by HPA to scale the PodClique based on metrics captured for the pods that match this selector.
 	Selector *string `json:"hpaPodSelector,omitempty"`

--- a/operator/api/core/v1alpha1/podgangset.go
+++ b/operator/api/core/v1alpha1/podgangset.go
@@ -270,7 +270,7 @@ type LastOperation struct {
 	// Description is a human-readable description of the last operation.
 	Description string `json:"description"`
 	// LastUpdateTime is the time at which the last operation was updated.
-	LastUpdateTime metav1.Time `json:"lastTransitionTime"`
+	LastUpdateTime metav1.Time `json:"lastUpdateTime"`
 }
 
 // ErrorCode is a custom error code that uniquely identifies an error.

--- a/operator/api/core/v1alpha1/scalinggroup.go
+++ b/operator/api/core/v1alpha1/scalinggroup.go
@@ -74,6 +74,10 @@ type PodCliqueScalingGroupSpec struct {
 type PodCliqueScalingGroupStatus struct {
 	// Replicas is the observed number of replicas for the PodCliqueScalingGroup.
 	Replicas int32 `json:"replicas,omitempty"`
+	// ScheduledReplicas is the number of replicas that are scheduled for the PodCliqueScalingGroup.
+	// A replica of PodCliqueScalingGroup is considered "scheduled" when at least MinAvailable number
+	// of pods in each constituent PodClique has been scheduled.
+	ScheduledReplicas int32 `json:"scheduledReplicas,omitempty"`
 	// Selector is the selector used to identify the pods that belong to this scaling group.
 	Selector *string `json:"selector,omitempty"`
 	// ObservedGeneration is the most recent generation observed by the controller.

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -68,7 +68,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 

--- a/operator/go.sum
+++ b/operator/go.sum
@@ -193,7 +193,7 @@ sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8
 sigs.k8s.io/randfill v0.0.0-20250304075658-069ef1bbf016/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
-sigs.k8s.io/structured-merge-diff/v4 v4.6.0 h1:IUA9nvMmnKWcj5jl84xn+T5MnlZKThmUW1TdblaLVAc=
-sigs.k8s.io/structured-merge-diff/v4 v4.6.0/go.mod h1:dDy58f92j70zLsuZVuUX5Wp9vtxXpaZnkPGWeqDfCps=
+sigs.k8s.io/structured-merge-diff/v4 v4.7.0 h1:qPeWmscJcXP0snki5IYF79Z8xrl8ETFxgMd7wez1XkI=
+sigs.k8s.io/structured-merge-diff/v4 v4.7.0/go.mod h1:dDy58f92j70zLsuZVuUX5Wp9vtxXpaZnkPGWeqDfCps=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/operator/internal/component/events/constants.go
+++ b/operator/internal/component/events/constants.go
@@ -1,0 +1,76 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package events
+
+// constants used for pod lifecycle events
+const (
+	// ReasonPodCreationSuccessful is an event reason which represents a successful creation of a Pod.
+	ReasonPodCreationSuccessful = "PodCreationSuccessful"
+	// ReasonPodCreationFailed is an event reason which represents that the creation of a Pod failed.
+	ReasonPodCreationFailed = "PodCreationFailed"
+	// ReasonPodDeletionSuccessful is an event reason which represents a successful deletion of a Pod.
+	ReasonPodDeletionSuccessful = "PodDeletionSuccessful"
+	// ReasonPodDeletionFailed is an event reason which represents that the deletion of a Pod failed.
+	ReasonPodDeletionFailed = "PodDeletionFailed"
+)
+
+// constants for PodClique lifecycle events
+const (
+	// ReasonPodCliqueCreationSuccessful is an event reason which represents a successful creation of a PodClique.
+	ReasonPodCliqueCreationSuccessful = "PodCliqueCreationSuccessful"
+	// ReasonPodCliqueCreationFailed is an event reason which represents that the creation of a PodClique failed.
+	ReasonPodCliqueCreationFailed = "PodCliqueCreationFailed"
+	// ReasonPodCliqueDeletionSuccessful is an event reason which represents a successful deletion of a PodClique.
+	ReasonPodCliqueDeletionSuccessful = "PodCliqueDeletionSuccessful"
+	// ReasonPodCliqueDeletionFailed is an event reason which represents that the deletion of a PodClique failed.
+	ReasonPodCliqueDeletionFailed = "PodCliqueDeletionFailed"
+)
+
+// constants for PodCliqueScalingGroup lifecycle events
+const (
+	// ReasonPodCliqueScalingGroupCreationSuccessful is an event which represents a successful creation of PodCliqueScalingGroup.
+	ReasonPodCliqueScalingGroupCreationSuccessful = "PodCliqueScalingGroupCreationSuccessful"
+	// ReasonPodCliqueScalingGroupCreationFailed is an event which represents that creation of PodCliqueScalingGroup failed.
+	ReasonPodCliqueScalingGroupCreationFailed = "PodCliqueScalingGroupCreationFailed"
+	// ReasonPodCliqueScalingGroupDeletionSuccessful is an event reason which represents a successful deletion of PodCliqueScalingGroup.
+	ReasonPodCliqueScalingGroupDeletionSuccessful = "PodCliqueScalingGroupDeletionSuccessful"
+	// ReasonPodCliqueScalingGroupDeletionFailed is an event which represents that the deletion of PodCliqueScalingGroup failed.
+	ReasonPodCliqueScalingGroupDeletionFailed = "PodCliqueScalingGroupDeletionFailed"
+	// ReasonPodCliqueScalingGroupReplicaDeletionSuccessful is an event reason which represents a successful deletion of a PodCliqueScalingGroup replica.
+	ReasonPodCliqueScalingGroupReplicaDeletionSuccessful = "PodCliqueScalingGroupReplicaDeletionSuccessful"
+	// ReasonPodCliqueScalingGroupReplicaDeletionFailed is an event which represents that the deletion of a replica of PodCliqueScalingGroup failed.
+	ReasonPodCliqueScalingGroupReplicaDeletionFailed = "PodCliqueScalingGroupReplicaDeletionFailed"
+)
+
+// constants for PodGang lifecycle events
+const (
+	// ReasonPodGangCreateOrUpdateSuccessful is an event reason which represents a successful creation or updating of a PodGang.
+	ReasonPodGangCreateOrUpdateSuccessful = "PodGangCreationOrUpdateSuccessful"
+	// ReasonPodGangCreateOrUpdateFailed is an event reason which represents that the creation or updating of PodGang failed.
+	ReasonPodGangCreateOrUpdateFailed = "PodGangCreationOrUpdateFailed"
+	// ReasonPodGangDeletionSuccessful is an event reason which represents a successful deletion of a PodGang.
+	ReasonPodGangDeletionSuccessful = "PodGangDeletionSuccessful"
+	// ReasonPodGangDeletionFailed is an event reason which represents that the deletion of a PodGang failed.
+	ReasonPodGangDeletionFailed = "PodGangDeletionFailed"
+)
+
+// constants for PodGangSet lifecycle events
+const (
+	ReasonPodGangSetReplicaDeletionSuccessful = "PodGangSetReplicaDeletionSuccessful"
+
+	ReasonPodGangSetReplicaDeletionFailed = "PodGangSetReplicaDeletionFailed"
+)

--- a/operator/internal/component/events/constants.go
+++ b/operator/internal/component/events/constants.go
@@ -58,10 +58,10 @@ const (
 
 // constants for PodGang lifecycle events
 const (
-	// ReasonPodGangCreateOrUpdateSuccessful is an event reason which represents a successful creation or updating of a PodGang.
-	ReasonPodGangCreateOrUpdateSuccessful = "PodGangCreationOrUpdateSuccessful"
-	// ReasonPodGangCreateOrUpdateFailed is an event reason which represents that the creation or updating of PodGang failed.
-	ReasonPodGangCreateOrUpdateFailed = "PodGangCreationOrUpdateFailed"
+	// ReasonPodGangCreationOrUpdationSuccessful is an event reason which represents a successful creation or updating of a PodGang.
+	ReasonPodGangCreationOrUpdationSuccessful = "PodGangCreationOrUpdateSuccessful"
+	// ReasonPodGangCreationOrUpdationFailed is an event reason which represents that the creation or updating of PodGang failed.
+	ReasonPodGangCreationOrUpdationFailed = "PodGangCreationOrUpdateFailed"
 	// ReasonPodGangDeletionSuccessful is an event reason which represents a successful deletion of a PodGang.
 	ReasonPodGangDeletionSuccessful = "PodGangDeletionSuccessful"
 	// ReasonPodGangDeletionFailed is an event reason which represents that the deletion of a PodGang failed.
@@ -70,7 +70,8 @@ const (
 
 // constants for PodGangSet lifecycle events
 const (
+	// ReasonPodGangSetReplicaDeletionSuccessful is an event reason which represents a successful deletion of a PodGangSet replica.
 	ReasonPodGangSetReplicaDeletionSuccessful = "PodGangSetReplicaDeletionSuccessful"
-
+	// ReasonPodGangSetReplicaDeletionFailed is an event reason which represents that the deletion of a PodGangSet replica failed.
 	ReasonPodGangSetReplicaDeletionFailed = "PodGangSetReplicaDeletionFailed"
 )

--- a/operator/internal/component/podclique/pod/pod.go
+++ b/operator/internal/component/podclique/pod/pod.go
@@ -19,18 +19,15 @@ package pod
 import (
 	"context"
 	"fmt"
-	"os"
+	"github.com/NVIDIA/grove/operator/internal/expect"
 	"strconv"
-	"strings"
 
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
-	"github.com/NVIDIA/grove/operator/internal/common"
 	"github.com/NVIDIA/grove/operator/internal/component"
 	componentutils "github.com/NVIDIA/grove/operator/internal/component/utils"
 	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
 	"github.com/NVIDIA/grove/operator/internal/utils"
 	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
-	"github.com/NVIDIA/grove/operator/internal/version"
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
@@ -42,39 +39,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	// envVarInitContainerImage stores the environment variable which is read to find the image for the initcontainer.
-	// The environment variable should only store the registry and repository of the initcontainer. It should not contain any tag.
-	envVarInitContainerImage string = "GROVE_INIT_CONTAINER_IMAGE"
-	// grove-initc name
-	initContainerName = "grove-initc"
-	// volumeNamePodInfo is the name of the downwardAPI volume that passes the pod information to the init container
-	volumeNamePodInfo = "pod-info"
-)
-
 // constants for error codes
 const (
-	errCodeGetPod    grovecorev1alpha1.ErrorCode = "ERR_GET_POD"
-	errCodeSyncPod   grovecorev1alpha1.ErrorCode = "ERR_SYNC_POD"
-	errCodeDeletePod grovecorev1alpha1.ErrorCode = "ERR_DELETE_POD"
-
-	errCodeGetPodGang                      grovecorev1alpha1.ErrorCode = "ERR_GET_PODGANG"
-	errCodeGetPodGangSet                   grovecorev1alpha1.ErrorCode = "ERR_GET_PODGANGSET"
-	errCodeGetPodClique                    grovecorev1alpha1.ErrorCode = "ERR_GET_PODCLIQUE"
-	errCodeListPod                         grovecorev1alpha1.ErrorCode = "ERR_LIST_POD"
-	errCodeRemovePodSchedulingGate         grovecorev1alpha1.ErrorCode = "ERR_REMOVE_POD_SCHEDULING_GATE"
-	errCodeCreatePods                      grovecorev1alpha1.ErrorCode = "ERR_CREATE_PODS"
-	errCodeMissingPodGangLabelOnPCLQ       grovecorev1alpha1.ErrorCode = "ERR_MISSING_PODGANG_LABEL_ON_PODCLIQUE"
-	errCodeInitContainerImageEnvVarMissing grovecorev1alpha1.ErrorCode = "ERR_INITCONTAINER_ENVIRONMENT_VARIABLE_MISSING"
-	errCodeMissingPodCliqueTemplate        grovecorev1alpha1.ErrorCode = "ERR_MISSING_PODCLIQUE_TEMPLATE"
-)
-
-// constants used for pod events
-const (
-	reasonPodCreationSuccessful = "PodCreationSuccessful"
-	reasonPodCreationFailed     = "PodCreationFailed"
-	reasonPodDeletionSuccessful = "PodDeletionSuccessful"
-	reasonPodDeletionFailed     = "PodDeletionFailed"
+	errCodeGetPod                              grovecorev1alpha1.ErrorCode = "ERR_GET_POD"
+	errCodeDeletePod                           grovecorev1alpha1.ErrorCode = "ERR_DELETE_POD"
+	errCodeGetAvailablePodHostNameIndices      grovecorev1alpha1.ErrorCode = "ERR_GET_AVAILABLE_POD_HOSTNAME_INDICES"
+	errCodeGetPodGang                          grovecorev1alpha1.ErrorCode = "ERR_GET_PODGANG"
+	errCodeGetPodGangSet                       grovecorev1alpha1.ErrorCode = "ERR_GET_PODGANGSET"
+	errCodeGetPodClique                        grovecorev1alpha1.ErrorCode = "ERR_GET_PODCLIQUE"
+	errCodeListPod                             grovecorev1alpha1.ErrorCode = "ERR_LIST_POD"
+	errCodeRemovePodSchedulingGate             grovecorev1alpha1.ErrorCode = "ERR_REMOVE_POD_SCHEDULING_GATE"
+	errCodeCreatePod                           grovecorev1alpha1.ErrorCode = "ERR_CREATE_POD"
+	errCodeMissingPodGangLabelOnPCLQ           grovecorev1alpha1.ErrorCode = "ERR_MISSING_PODGANG_LABEL_ON_PODCLIQUE"
+	errCodeCreatePodCliqueExpectationsStoreKey grovecorev1alpha1.ErrorCode = "ERR_CREATE_PODCLIQUE_EXPECTATIONS_STORE_KEY"
+	errCodeDeletePodCliqueExpectations         grovecorev1alpha1.ErrorCode = "ERR_DELETE_PODCLIQUE_EXPECTATIONS_STORE_KEY"
+	errCodeGetPodGangSetReplicaIndex           grovecorev1alpha1.ErrorCode = "ERR_GET_PODGANGSET_REPLICA_INDEX"
+	errCodeSetControllerReference              grovecorev1alpha1.ErrorCode = "ERR_SET_CONTROLLER_REFERENCE"
+	errCodeBuildPodResource                    grovecorev1alpha1.ErrorCode = "ERR_BUILD_POD_RESOURCE"
 )
 
 const (
@@ -82,17 +63,19 @@ const (
 )
 
 type _resource struct {
-	client        client.Client
-	scheme        *runtime.Scheme
-	eventRecorder record.EventRecorder
+	client            client.Client
+	scheme            *runtime.Scheme
+	eventRecorder     record.EventRecorder
+	expectationsStore *expect.ExpectationsStore
 }
 
 // New creates an instance of Pod component operator.
-func New(client client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder) component.Operator[grovecorev1alpha1.PodClique] {
+func New(client client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder, expectationsStore *expect.ExpectationsStore) component.Operator[grovecorev1alpha1.PodClique] {
 	return &_resource{
-		client:        client,
-		scheme:        scheme,
-		eventRecorder: eventRecorder,
+		client:            client,
+		scheme:            scheme,
+		eventRecorder:     eventRecorder,
+		expectationsStore: expectationsStore,
 	}
 }
 
@@ -128,7 +111,7 @@ func (r _resource) Sync(ctx context.Context, logger logr.Logger, pclq *grovecore
 	if err != nil {
 		return err
 	}
-	result := r.runSyncFlow(sc, logger)
+	result := r.runSyncFlow(logger, sc)
 	if result.hasErrors() {
 		return result.getAggregatedError()
 	}
@@ -141,13 +124,13 @@ func (r _resource) Sync(ctx context.Context, logger logr.Logger, pclq *grovecore
 	return nil
 }
 
-func (r _resource) buildResource(pgs *grovecorev1alpha1.PodGangSet, pclq *grovecorev1alpha1.PodClique, podGangName string, pod *corev1.Pod, podIndex int) error {
+func (r _resource) buildResource(pclq *grovecorev1alpha1.PodClique, podGangName string, pod *corev1.Pod, podIndex int) error {
 	// Extract PGS replica index from PodClique name for now (will be replaced with direct parameter)
 	pgsName := componentutils.GetPodGangSetName(pclq.ObjectMeta)
 	pgsReplicaIndex, err := utils.GetPodGangSetReplicaIndexFromPodCliqueFQN(pgsName, pclq.Name)
 	if err != nil {
 		return groveerr.WrapError(err,
-			errCodeSyncPod,
+			errCodeGetPodGangSetReplicaIndex,
 			component.OperationSync,
 			fmt.Sprintf("error extracting PGS replica index for PodClique %v", client.ObjectKeyFromObject(pclq)),
 		)
@@ -161,20 +144,19 @@ func (r _resource) buildResource(pgs *grovecorev1alpha1.PodGangSet, pclq *grovec
 	}
 	if err = controllerutil.SetControllerReference(pclq, pod, r.scheme); err != nil {
 		return groveerr.WrapError(err,
-			errCodeSyncPod,
+			errCodeSetControllerReference,
 			component.OperationSync,
 			fmt.Sprintf("error setting controller reference of PodClique: %v on Pod", client.ObjectKeyFromObject(pclq)),
 		)
 	}
 	pod.Spec = *pclq.Spec.PodSpec.DeepCopy()
 	pod.Spec.SchedulingGates = []corev1.PodSchedulingGate{{Name: podGangSchedulingGate}}
-	pod.Spec.ServiceAccountName = grovecorev1alpha1.GeneratePodServiceAccountName(pgs.Name)
 
 	addEnvironmentVariables(pod, pclq, pgsName, pgsReplicaIndex, podIndex)
 	// Configure hostname and subdomain for service discovery
-	configurePodHostname(pod, pclq.Name, podIndex, pgsName, pgsReplicaIndex)
+	configurePodHostname(pgsName, pgsReplicaIndex, pclq.Name, pod, podIndex)
 
-	return appendGroveInitContainerIfNeeded(pgs, pclq, pod)
+	return nil
 }
 
 func (r _resource) Delete(ctx context.Context, logger logr.Logger, pclqObjectMeta metav1.ObjectMeta) error {
@@ -188,6 +170,16 @@ func (r _resource) Delete(ctx context.Context, logger logr.Logger, pclqObjectMet
 			component.OperationDelete,
 			fmt.Sprintf("failed to delete all pods for PodClique %v", k8sutils.GetObjectKeyFromObjectMeta(pclqObjectMeta)),
 		)
+	}
+	pclqExpStoreKey, err := getPodCliqueExpectationsStoreKey(logger, component.OperationDelete, pclqObjectMeta)
+	if err != nil {
+		return err
+	}
+	if err = r.expectationsStore.DeleteExpectations(logger, pclqExpStoreKey); err != nil {
+		return groveerr.WrapError(err,
+			errCodeDeletePodCliqueExpectations,
+			component.OperationDelete,
+			fmt.Sprintf("failed to delete expectations store for PodClique %v", pclqObjectMeta.Name))
 	}
 	logger.Info("Successfully deleted all pods for the PodClique")
 	return nil
@@ -213,77 +205,6 @@ func getLabels(pclqObjectMeta metav1.ObjectMeta, pgsName, podGangName string, pg
 		k8sutils.GetDefaultLabelsForPodGangSetManagedResources(pgsName),
 		pclqObjectMeta.Labels,
 		labels)
-}
-
-func appendGroveInitContainerIfNeeded(pgs *grovecorev1alpha1.PodGangSet, pclq *grovecorev1alpha1.PodClique, pod *corev1.Pod) error {
-	if len(pclq.Spec.StartsAfter) == 0 {
-		return nil
-	}
-	initContainerImage, ok := os.LookupEnv(envVarInitContainerImage)
-	if !ok {
-		return groveerr.New(
-			errCodeInitContainerImageEnvVarMissing,
-			component.OperationSync,
-			"environment variable specifying the initcontainer image is missing",
-		)
-	}
-	args, err := generateArgsForInitc(pgs, pclq)
-	if err != nil {
-		return err
-	}
-
-	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
-		Name:  initContainerName,
-		Image: fmt.Sprintf("%s:%s", initContainerImage, version.Get().GitVersion),
-		Args:  args,
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      volumeNamePodInfo,
-				ReadOnly:  true,
-				MountPath: common.VolumeMountPathPodInfo,
-			},
-		},
-	})
-	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
-		Name: volumeNamePodInfo,
-		VolumeSource: corev1.VolumeSource{
-			DownwardAPI: &corev1.DownwardAPIVolumeSource{
-				Items: []corev1.DownwardAPIVolumeFile{
-					{
-						Path: common.PodNamespaceFileName,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.namespace",
-						},
-					},
-					{
-						Path: common.PodGangNameFileName,
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: fmt.Sprintf("metadata.labels['%s']", grovecorev1alpha1.LabelPodGang),
-						},
-					},
-				},
-			},
-		},
-	})
-	return nil
-}
-
-func generateArgsForInitc(pgs *grovecorev1alpha1.PodGangSet, pclq *grovecorev1alpha1.PodClique) ([]string, error) {
-	args := make([]string, 0)
-	for _, parentClique := range pclq.Spec.StartsAfter {
-		parentCliqueTemplateSpec, ok := lo.Find(pgs.Spec.Template.Cliques, func(templateSpec *grovecorev1alpha1.PodCliqueTemplateSpec) bool {
-			return strings.HasSuffix(parentClique, templateSpec.Name)
-		})
-		if !ok {
-			return nil, groveerr.New(
-				errCodeMissingPodCliqueTemplate,
-				component.OperationSync,
-				fmt.Sprintf("PodClique %s specified in startsAfter is not present in the templates", parentClique),
-			)
-		}
-		args = append(args, fmt.Sprintf("--podcliques=%s:%d", parentClique, *parentCliqueTemplateSpec.Spec.MinAvailable))
-	}
-	return args, nil
 }
 
 // addEnvironmentVariables adds Grove-specific environment variables to all containers and init-containers.
@@ -317,7 +238,7 @@ func addEnvironmentVariables(pod *corev1.Pod, pclq *grovecorev1alpha1.PodClique,
 }
 
 // configurePodHostname sets the pod hostname and subdomain for service discovery
-func configurePodHostname(pod *corev1.Pod, pclqName string, podIndex int, pgsName string, pgsReplicaIndex int) {
+func configurePodHostname(pgsName string, pgsReplicaIndex int, pclqName string, pod *corev1.Pod, podIndex int) {
 	// Set hostname for service discovery (e.g., "my-pclq-0")
 	pod.Spec.Hostname = fmt.Sprintf("%s-%d", pclqName, podIndex)
 

--- a/operator/internal/component/podclique/pod/syncflow.go
+++ b/operator/internal/component/podclique/pod/syncflow.go
@@ -382,7 +382,7 @@ func (r _resource) createPods(ctx context.Context, logger logr.Logger, sc *syncC
 		// Get the available Pod host name index. This ensures that we fill the holes in the indices if there are any when creating
 		// new pods.
 		podHostNameIndex := availableIndices[i]
-		createTasks = append(createTasks, r.podCreationTask(logger, sc.pclq, sc.associatedPodGangName, sc.pclqExpectationsStoreKey, i, podHostNameIndex))
+		createTasks = append(createTasks, r.podCreationTask(logger, sc.pgs, sc.pclq, sc.associatedPodGangName, sc.pclqExpectationsStoreKey, i, podHostNameIndex))
 	}
 	runResult := utils.RunConcurrentlyWithSlowStart(ctx, logger, 1, createTasks)
 	if runResult.HasErrors() {

--- a/operator/internal/component/podclique/pod/syncflow.go
+++ b/operator/internal/component/podclique/pod/syncflow.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/NVIDIA/grove/operator/internal/expect"
 	"slices"
 	"sort"
 
@@ -37,15 +38,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// prepareSyncFlow gathers information in preparation for the sync flow to run.
 func (r _resource) prepareSyncFlow(ctx context.Context, logger logr.Logger, pclq *grovecorev1alpha1.PodClique) (*syncContext, error) {
 	sc := &syncContext{
 		ctx:  ctx,
 		pclq: pclq,
 	}
 
+	// Get associated PodGangSet for this PodClique.
 	associatedPodGangSet, err := componentutils.GetOwnerPodGangSet(ctx, r.client, pclq.ObjectMeta)
 	if err != nil {
 		return nil, groveerr.WrapError(err,
@@ -56,21 +60,33 @@ func (r _resource) prepareSyncFlow(ctx context.Context, logger logr.Logger, pclq
 	}
 	sc.pgs = associatedPodGangSet
 
+	// get the PCLQ expectations key
+	pclqExpStoreKey, err := getPodCliqueExpectationsStoreKey(logger, component.OperationSync, pclq.ObjectMeta)
+	if err != nil {
+		return nil, err
+	}
+	sc.pclqExpectationsStoreKey = pclqExpStoreKey
+
+	// get the associated PodGang name.
 	associatedPodGangName, err := r.getAssociatedPodGangName(pclq.ObjectMeta)
 	if err != nil {
 		return nil, err
 	}
 	sc.associatedPodGangName = associatedPodGangName
 
+	// Get the associated PodGang resource.
 	existingPodGang, err := componentutils.GetPodGang(ctx, r.client, sc.associatedPodGangName, pclq.Namespace)
 	if err = lo.Ternary(apierrors.IsNotFound(err), nil, err); err != nil {
 		return nil, err
 	}
+
+	// initialize the Pod names that are updated in the PodGang resource for this PCLQ.
 	sc.podNamesUpdatedInPCLQPodGangs = r.getPodNamesUpdatedInAssociatedPodGang(existingPodGang, pclq.Name)
 
+	// Get all existing pods for this PCLQ.
 	existingPCLQPods, err := componentutils.GetPCLQPods(ctx, r.client, sc.pgs.Name, pclq)
 	if err != nil {
-		logger.Error(err, "Failed to list pods that belong to PodClique", "pclqObjectKey", client.ObjectKeyFromObject(pclq))
+		logger.Error(err, "Failed to list pods that belong to PodClique")
 		return nil, groveerr.WrapError(err,
 			errCodeListPod,
 			component.OperationSync,
@@ -82,6 +98,7 @@ func (r _resource) prepareSyncFlow(ctx context.Context, logger logr.Logger, pclq
 	return sc, nil
 }
 
+// getAssociatedPodGangName gets the associated PodGang name from PodClique labels. Returns an error if the label is not found.
 func (r _resource) getAssociatedPodGangName(pclqObjectMeta metav1.ObjectMeta) (string, error) {
 	podGangName, ok := pclqObjectMeta.GetLabels()[grovecorev1alpha1.LabelPodGang]
 	if !ok {
@@ -93,6 +110,7 @@ func (r _resource) getAssociatedPodGangName(pclqObjectMeta metav1.ObjectMeta) (s
 	return podGangName, nil
 }
 
+// getPodNamesUpdatedInAssociatedPodGang gathers all Pod names that are already updated in PodGroups defined in the PodGang resource.
 func (r _resource) getPodNamesUpdatedInAssociatedPodGang(existingPodGang *groveschedulerv1alpha1.PodGang, pclqFQN string) []string {
 	if existingPodGang == nil {
 		return nil
@@ -108,18 +126,19 @@ func (r _resource) getPodNamesUpdatedInAssociatedPodGang(existingPodGang *groves
 	})
 }
 
-func (r _resource) runSyncFlow(sc *syncContext, logger logr.Logger) syncFlowResult {
+// runSyncFlow runs the synchronization flow for this component.
+func (r _resource) runSyncFlow(logger logr.Logger, sc *syncContext) syncFlowResult {
 	result := syncFlowResult{}
-	diff := len(sc.existingPCLQPods) - int(sc.pclq.Spec.Replicas)
+	diff := r.syncExpectationsAndComputeDifference(logger, sc)
 	if diff < 0 {
-		logger.Info("found fewer pods than desired", "pclq", client.ObjectKeyFromObject(sc.pclq), "specReplicas", sc.pclq.Spec.Replicas, "delta", diff)
+		logger.Info("found fewer pods than desired", "pclq.spec.replicas", sc.pclq.Spec.Replicas, "delta", diff)
 		diff *= -1
-		numScheduleGatedPods, err := r.createPods(sc.ctx, logger, sc.pgs, sc.pclq, sc.associatedPodGangName, diff, sc.existingPCLQPods)
-		logger.Info("created unassigned and scheduled gated pods", "numberOfCreatedPods", numScheduleGatedPods)
+		numScheduleGatedPods, err := r.createPods(sc.ctx, logger, sc, diff)
 		if err != nil {
-			logger.Error(err, "failed to create pods", "pclqObjectKey", client.ObjectKeyFromObject(sc.pclq))
+			logger.Error(err, "failed to create pods")
 			result.recordError(err)
 		}
+		logger.Info("created unassigned and scheduled gated pods", "numberOfCreatedPods", numScheduleGatedPods)
 	} else if diff > 0 {
 		if err := r.deleteExcessPods(sc, logger, diff); err != nil {
 			result.recordError(err)
@@ -134,37 +153,43 @@ func (r _resource) runSyncFlow(sc *syncContext, logger logr.Logger) syncFlowResu
 	return result
 }
 
+// syncExpectationsAndComputeDifference synchronizes expectations that are captured against the owning PodClique resource.
+// It takes in the existing pods and adjusts the captured create/delete expectations in the ExpectationStore. Post synchronization
+// it computes the difference of pods using => as-is-pods + pods-expecting-creation - desired-pods - pods-expecting-deletion
+func (r _resource) syncExpectationsAndComputeDifference(logger logr.Logger, sc *syncContext) int {
+	r.expectationsStore.SyncExpectations(sc.pclqExpectationsStoreKey, lo.Map(sc.existingPCLQPods, func(pod *corev1.Pod, _ int) types.UID { return pod.GetUID() })...)
+	createExpectations := r.expectationsStore.GetCreateExpectations(sc.pclqExpectationsStoreKey)
+	deleteExpectations := r.expectationsStore.GetDeleteExpectations(sc.pclqExpectationsStoreKey)
+	diff := len(sc.existingPCLQPods) + len(createExpectations) - int(sc.pclq.Spec.Replicas) - len(deleteExpectations)
+
+	logger.V(4).Info("synced expectations",
+		"pclq.spec.replicas", sc.pclq.Spec.Replicas,
+		"existingPCLPodNames", lo.Map(sc.existingPCLQPods, func(pod *corev1.Pod, _ int) string { return pod.Name }),
+		"createExpectations", createExpectations,
+		"deleteExpectations", deleteExpectations,
+		"diff", diff,
+	)
+	return diff
+}
+
+// deleteExcessPods deletes `diff` number of excess Pods from this PodClique concurrently.
+// It selects the pods using `DeletionSorter`. For details please see `DeletionSorter.Less` method.
+// The deletion of Pods are done in batches of increasing size. This is done to prevent burst of load
+// on the kube-apiserver. It will fail fast in case there is an
 func (r _resource) deleteExcessPods(sc *syncContext, logger logr.Logger, diff int) error {
 	candidatePodsToDelete := selectExcessPodsToDelete(sc, logger)
 	numPodsToSelectForDeletion := min(diff, len(candidatePodsToDelete))
 	selectedPodsToDelete := candidatePodsToDelete[:numPodsToSelectForDeletion]
 
 	deleteTasks := make([]utils.Task, 0, len(selectedPodsToDelete))
-	for i, podToDelete := range selectedPodsToDelete {
-		podObjectKey := client.ObjectKeyFromObject(podToDelete)
-		deleteTask := utils.Task{
-			Name: fmt.Sprintf("DeletePod-%s-%d", podToDelete.Name, i),
-			Fn: func(ctx context.Context) error {
-				if err := client.IgnoreNotFound(r.client.Delete(ctx, podToDelete)); err != nil {
-					r.eventRecorder.Eventf(sc.pclq, corev1.EventTypeWarning, reasonPodDeletionFailed, "Error deleting pod: %v", err)
-					return groveerr.WrapError(err,
-						errCodeDeletePod,
-						component.OperationSync,
-						fmt.Sprintf("failed to delete Pod: %v for PodClique %v", podObjectKey, client.ObjectKeyFromObject(sc.pclq)),
-					)
-				}
-				logger.Info("Deleted Pod", "podObjectKey", podObjectKey)
-				r.eventRecorder.Eventf(sc.pclq, corev1.EventTypeNormal, reasonPodDeletionSuccessful, "Deleted Pod: %s", podToDelete.Name)
-				return nil
-			},
-		}
-		deleteTasks = append(deleteTasks, deleteTask)
+	for _, podToDelete := range selectedPodsToDelete {
+		deleteTasks = append(deleteTasks, r.podDeletionTask(logger, sc.pclq, podToDelete, sc.pclqExpectationsStoreKey))
 	}
 
 	if runResult := utils.RunConcurrentlyWithSlowStart(sc.ctx, logger, 1, deleteTasks); runResult.HasErrors() {
 		err := runResult.GetAggregatedError()
 		pclqObjectKey := client.ObjectKeyFromObject(sc.pclq)
-		logger.Error(err, "failed to delete pods for PCLQ", "pclqObjectKey", pclqObjectKey, "runSummary", runResult.GetSummary())
+		logger.Error(err, "failed to delete pods for PCLQ", "runSummary", runResult.GetSummary())
 		return groveerr.WrapError(err,
 			errCodeDeletePod,
 			component.OperationSync,
@@ -178,7 +203,7 @@ func (r _resource) deleteExcessPods(sc *syncContext, logger logr.Logger, diff in
 func selectExcessPodsToDelete(sc *syncContext, logger logr.Logger) []*corev1.Pod {
 	var candidatePodsToDelete []*corev1.Pod
 	if diff := len(sc.existingPCLQPods) - int(sc.pclq.Spec.Replicas); diff > 0 {
-		logger.Info("found excess pods for PodClique", "pclqObjectKey", client.ObjectKeyFromObject(sc.pclq), "numExcessPods", diff)
+		logger.Info("found excess pods for PodClique", "numExcessPods", diff)
 		sort.Sort(DeletionSorter(sc.existingPCLQPods))
 		candidatePodsToDelete = append(candidatePodsToDelete, sc.existingPCLQPods[:diff]...)
 	}
@@ -234,7 +259,7 @@ func (r _resource) checkAndRemovePodSchedulingGates(sc *syncContext, logger logr
 		pclqObjectKey := client.ObjectKeyFromObject(sc.pclq)
 		if runResult := utils.RunConcurrentlyWithSlowStart(sc.ctx, logger, 1, tasks); runResult.HasErrors() {
 			err := runResult.GetAggregatedError()
-			logger.Error(err, "failed to remove scheduling gates from pods for PCLQ", "pclqObjectKey", pclqObjectKey, "runSummary", runResult.GetSummary())
+			logger.Error(err, "failed to remove scheduling gates from pods for PCLQ", "runSummary", runResult.GetSummary())
 			return skippedScheduleGatedPods, groveerr.WrapError(err,
 				errCodeRemovePodSchedulingGate,
 				component.OperationSync,
@@ -342,62 +367,33 @@ func hasPodGangSchedulingGate(pod *corev1.Pod) bool {
 	})
 }
 
-func (r _resource) createPods(ctx context.Context, logger logr.Logger, pgs *grovecorev1alpha1.PodGangSet, pclq *grovecorev1alpha1.PodClique, podGangName string, numPods int, existingPods []*corev1.Pod) (int, error) {
+func (r _resource) createPods(ctx context.Context, logger logr.Logger, sc *syncContext, numPods int) (int, error) {
 	// Pre-calculate all needed indices to avoid race conditions
-	availableIndices, err := index.GetAvailableIndices(existingPods, numPods)
+	availableIndices, err := index.GetAvailableIndices(sc.existingPCLQPods, numPods)
 	if err != nil {
 		return 0, groveerr.WrapError(err,
-			errCodeSyncPod,
+			errCodeGetAvailablePodHostNameIndices,
 			component.OperationSync,
-			fmt.Sprintf("error getting available indices for Pods in PodClique %v", client.ObjectKeyFromObject(pclq)),
+			fmt.Sprintf("error getting available indices for Pods in PodClique %v", client.ObjectKeyFromObject(sc.pclq)),
 		)
 	}
-
 	createTasks := make([]utils.Task, 0, numPods)
-
 	for i := range numPods {
-		podIndex := availableIndices[i] // Capture the specific index for this pod
-		createTask := utils.Task{
-			Name: fmt.Sprintf("CreatePod-%s-%d", pclq.Name, i),
-			Fn: func(ctx context.Context) error {
-				pod := &corev1.Pod{}
-				if err := r.buildResource(pgs, pclq, podGangName, pod, podIndex); err != nil {
-					return groveerr.WrapError(err,
-						errCodeSyncPod,
-						component.OperationSync,
-						fmt.Sprintf("failed to build Pod resource for PodClique %v", client.ObjectKeyFromObject(pclq)),
-					)
-				}
-				if err := r.client.Create(ctx, pod); err != nil {
-					r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, reasonPodCreationFailed, "Error creating pod: %v", err)
-					return groveerr.WrapError(err,
-						errCodeSyncPod,
-						component.OperationSync,
-						fmt.Sprintf("failed to create Pod: %v for PodClique %v", client.ObjectKeyFromObject(pod), client.ObjectKeyFromObject(pclq)),
-					)
-				}
-				logger.Info("Created pod for PodClique", "pclqName", pclq.Name, "podName", pod.Name)
-				r.eventRecorder.Eventf(pclq, corev1.EventTypeNormal, reasonPodCreationSuccessful, "Created Pod: %s", pod.Name)
-				return nil
-			},
-		}
-		createTasks = append(createTasks, createTask)
+		// Get the available Pod host name index. This ensures that we fill the holes in the indices if there are any when creating
+		// new pods.
+		podHostNameIndex := availableIndices[i]
+		createTasks = append(createTasks, r.podCreationTask(logger, sc.pclq, sc.associatedPodGangName, sc.pclqExpectationsStoreKey, i, podHostNameIndex))
 	}
 	runResult := utils.RunConcurrentlyWithSlowStart(ctx, logger, 1, createTasks)
 	if runResult.HasErrors() {
-		err := runResult.GetAggregatedError()
-		pclqObjectKey := client.ObjectKeyFromObject(pclq)
-		logger.Error(err, "failed to create pods for PCLQ", "pclqObjectKey", pclqObjectKey, "runSummary", runResult.GetSummary())
-		return 0, groveerr.WrapError(err,
-			errCodeCreatePods,
-			component.OperationSync,
-			fmt.Sprintf("failed to create Pods for PodClique %v", pclqObjectKey),
-		)
+		err = runResult.GetAggregatedError()
+		logger.Error(err, "failed to create pods for PCLQ", "runSummary", runResult.GetSummary())
+		return 0, err
 	}
 	return len(runResult.SuccessfulTasks), nil
 }
 
-// Convenience types and methods on these types that are used during sync flow run.
+// Convenience functions, types and methods on these types that are used during sync flow run.
 // ------------------------------------------------------------------------------------------------
 
 // syncContext holds the relevant state required during the sync flow run.
@@ -408,6 +404,7 @@ type syncContext struct {
 	associatedPodGangName         string
 	existingPCLQPods              []*corev1.Pod
 	podNamesUpdatedInPCLQPodGangs []string
+	pclqExpectationsStoreKey      string
 }
 
 // syncFlowResult captures the result of a sync flow run.
@@ -436,4 +433,19 @@ func (sfr *syncFlowResult) recordPendingScheduleGatedPods(podNames []string) {
 
 func (sfr *syncFlowResult) hasErrors() bool {
 	return len(sfr.errs) > 0
+}
+
+// getPodCliqueExpectationsStoreKey creates the PodClique key against which expectations will be stored in the ExpectationStore.
+func getPodCliqueExpectationsStoreKey(logger logr.Logger, operation string, pclqObjMeta metav1.ObjectMeta) (string, error) {
+	pclqObjKey := k8sutils.GetObjectKeyFromObjectMeta(pclqObjMeta)
+	pclqExpStoreKey, err := expect.ControlleeKeyFunc(&grovecorev1alpha1.PodClique{ObjectMeta: pclqObjMeta})
+	if err != nil {
+		logger.Error(err, "failed to construct expectations store key", "pclq", pclqObjKey)
+		return "", groveerr.WrapError(err,
+			errCodeCreatePodCliqueExpectationsStoreKey,
+			operation,
+			fmt.Sprintf("failed to construct expectations store key for PodClique %v", pclqObjKey),
+		)
+	}
+	return pclqExpStoreKey, nil
 }

--- a/operator/internal/component/podclique/pod/syncflow_test.go
+++ b/operator/internal/component/podclique/pod/syncflow_test.go
@@ -246,8 +246,8 @@ func TestCheckAndRemovePodSchedulingGates_ConcurrentExecution(t *testing.T) {
 	// Test that multiple pods can have their gates removed concurrently without race conditions
 
 	// Create multiple pods with gates for base PodGang (should all be processed)
-	pods := []*corev1.Pod{}
-	objects := []client.Object{}
+	var pods []*corev1.Pod
+	var objects []client.Object
 
 	for i := 0; i < 5; i++ {
 		pod := createTestPod("simple1-0", true, true) // Base PodGang, has gate, in PodGang

--- a/operator/internal/component/podclique/pod/task.go
+++ b/operator/internal/component/podclique/pod/task.go
@@ -1,0 +1,103 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package pod
+
+import (
+	"context"
+	"fmt"
+
+	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	"github.com/NVIDIA/grove/operator/internal/component"
+	groveevents "github.com/NVIDIA/grove/operator/internal/component/events"
+	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
+	"github.com/NVIDIA/grove/operator/internal/utils"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// podCreationTask creates a utils.Task which will create a Pod, capture the create-expectation and also emit a success/failed event post creation.
+func (r _resource) podCreationTask(logger logr.Logger, pclq *grovecorev1alpha1.PodClique, podGangName, pclqExpectationsKey string, taskIndex, podHostNameIndex int) utils.Task {
+	pclqObjKey := client.ObjectKeyFromObject(pclq)
+	return utils.Task{
+		Name: fmt.Sprintf("CreatePod-%s-%d", pclq.Name, taskIndex),
+		Fn: func(ctx context.Context) error {
+			pod := &corev1.Pod{}
+			// build the Pod resource
+			if err := r.buildResource(pclq, podGangName, pod, podHostNameIndex); err != nil {
+				return groveerr.WrapError(err,
+					errCodeBuildPodResource,
+					component.OperationSync,
+					fmt.Sprintf("failed to build Pod resource for PodClique %v", pclqObjKey),
+				)
+			}
+			// create the Pod
+			if err := r.client.Create(ctx, pod); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					logger.Info("pod creation failed as it already exists, ignoring the error", "pod", pod.Name)
+					return nil
+				}
+				r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, groveevents.ReasonPodCreationFailed, "Error creating pod %v: %v", pod.Name, err)
+				return groveerr.WrapError(err,
+					errCodeCreatePod,
+					component.OperationSync,
+					fmt.Sprintf("failed to create Pod: %s for PodClique %v", pod.Name, pclqObjKey),
+				)
+			}
+			logger.Info("Created Pod for PodClique", "podName", pod.Name, "podUID", pod.GetUID())
+			if err := r.expectationsStore.ExpectCreations(logger, pclqExpectationsKey, pod.GetUID()); err != nil {
+				utilruntime.HandleErrorWithLogger(logger, err, "could not record create expectations for Pod", "pclqObjKey", pclqObjKey, "pod", pod.Name)
+			}
+			r.eventRecorder.Eventf(pclq, corev1.EventTypeNormal, groveevents.ReasonPodCreationSuccessful, "Created Pod: %s", pod.Name)
+			return nil
+		},
+	}
+}
+
+// podDeletionTask creates a utils.Task which will delete a Pod, capture the delete-expectation and also emit a success/failed event post deletion.
+func (r _resource) podDeletionTask(logger logr.Logger, pclq *grovecorev1alpha1.PodClique, podToDelete *corev1.Pod, pclqExpectationsKey string) utils.Task {
+	podObjKey := client.ObjectKeyFromObject(podToDelete)
+	pclqObjKey := client.ObjectKeyFromObject(pclq)
+	return utils.Task{
+		Name: fmt.Sprintf("DeletePod-%s", podToDelete.Name),
+		Fn: func(ctx context.Context) error {
+			if err := r.client.Delete(ctx, podToDelete); err != nil {
+				if apierrors.IsNotFound(err) {
+					logger.Info("pod has already been deleted", "pod", podObjKey)
+					r.expectationsStore.ObserveDeletions(logger, pclqExpectationsKey, podToDelete.GetUID())
+					return nil
+				}
+				r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, groveevents.ReasonPodDeletionFailed, "Error deleting pod: %v", err)
+				return groveerr.WrapError(err,
+					errCodeDeletePod,
+					component.OperationSync,
+					fmt.Sprintf("failed to delete Pod: %v for PodClique %v", podObjKey, pclqObjKey),
+				)
+			}
+
+			logger.Info("Deleted Pod", "podObjectKey", podObjKey)
+			if err := r.expectationsStore.ExpectDeletions(logger, pclqExpectationsKey, podToDelete.GetUID()); err != nil {
+				utilruntime.HandleErrorWithLogger(logger, err, "could not record delete expectation", "pclq", pclqObjKey, "pod", podObjKey)
+			}
+			r.eventRecorder.Eventf(pclq, corev1.EventTypeNormal, groveevents.ReasonPodDeletionSuccessful, "Deleted Pod: %s", podToDelete.Name)
+			return nil
+		},
+	}
+}

--- a/operator/internal/component/podclique/pod/task.go
+++ b/operator/internal/component/podclique/pod/task.go
@@ -34,14 +34,14 @@ import (
 )
 
 // podCreationTask creates a utils.Task which will create a Pod, capture the create-expectation and also emit a success/failed event post creation.
-func (r _resource) podCreationTask(logger logr.Logger, pclq *grovecorev1alpha1.PodClique, podGangName, pclqExpectationsKey string, taskIndex, podHostNameIndex int) utils.Task {
+func (r _resource) podCreationTask(logger logr.Logger, pgs *grovecorev1alpha1.PodGangSet, pclq *grovecorev1alpha1.PodClique, podGangName, pclqExpectationsKey string, taskIndex, podHostNameIndex int) utils.Task {
 	pclqObjKey := client.ObjectKeyFromObject(pclq)
 	return utils.Task{
 		Name: fmt.Sprintf("CreatePod-%s-%d", pclq.Name, taskIndex),
 		Fn: func(ctx context.Context) error {
 			pod := &corev1.Pod{}
 			// build the Pod resource
-			if err := r.buildResource(pclq, podGangName, pod, podHostNameIndex); err != nil {
+			if err := r.buildResource(pgs, pclq, podGangName, pod, podHostNameIndex); err != nil {
 				return groveerr.WrapError(err,
 					errCodeBuildPodResource,
 					component.OperationSync,

--- a/operator/internal/component/podclique/pod/task.go
+++ b/operator/internal/component/podclique/pod/task.go
@@ -50,10 +50,6 @@ func (r _resource) podCreationTask(logger logr.Logger, pgs *grovecorev1alpha1.Po
 			}
 			// create the Pod
 			if err := r.client.Create(ctx, pod); err != nil {
-				if apierrors.IsAlreadyExists(err) {
-					logger.Info("pod creation failed as it already exists, ignoring the error", "pod", pod.Name)
-					return nil
-				}
 				r.eventRecorder.Eventf(pclq, corev1.EventTypeWarning, groveevents.ReasonPodCreationFailed, "Error creating pod %v: %v", pod.Name, err)
 				return groveerr.WrapError(err,
 					errCodeCreatePod,

--- a/operator/internal/component/podclique/registry.go
+++ b/operator/internal/component/podclique/registry.go
@@ -20,14 +20,15 @@ import (
 	"github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"
 	"github.com/NVIDIA/grove/operator/internal/component/podclique/pod"
+	"github.com/NVIDIA/grove/operator/internal/expect"
 
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // CreateOperatorRegistry initializes the operator registry for the PodClique reconciler.
-func CreateOperatorRegistry(mgr manager.Manager, eventRecorder record.EventRecorder) component.OperatorRegistry[v1alpha1.PodClique] {
+func CreateOperatorRegistry(mgr manager.Manager, eventRecorder record.EventRecorder, expectationsStore *expect.ExpectationsStore) component.OperatorRegistry[v1alpha1.PodClique] {
 	reg := component.NewOperatorRegistry[v1alpha1.PodClique]()
-	reg.Register(component.KindPod, pod.New(mgr.GetClient(), mgr.GetScheme(), eventRecorder))
+	reg.Register(component.KindPod, pod.New(mgr.GetClient(), mgr.GetScheme(), eventRecorder, expectationsStore))
 	return reg
 }

--- a/operator/internal/component/podgangset/podclique/podclique_test.go
+++ b/operator/internal/component/podgangset/podclique/podclique_test.go
@@ -33,6 +33,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -106,7 +107,7 @@ func TestGetExistingResourceNames(t *testing.T) {
 			existingObjects := createExistingPodCliquesFromPGS(pgs, tc.podCliqueNamesNotOwnedByPGS)
 			// Create a fake client with PodCliques
 			cl := testutils.CreateFakeClientForObjectsMatchingLabels(nil, tc.listErr, pgs.Namespace, grovecorev1alpha1.SchemeGroupVersion.WithKind("PodClique"), getPodCliqueSelectorLabels(pgs.ObjectMeta), existingObjects...)
-			operator := New(cl, groveclientscheme.Scheme)
+			operator := New(cl, groveclientscheme.Scheme, record.NewFakeRecorder(10))
 			actualPCLQNames, err := operator.GetExistingResourceNames(context.Background(), logr.Discard(), pgs.ObjectMeta)
 			if tc.expectedErr == nil {
 				assert.NoError(t, err)
@@ -159,7 +160,7 @@ func TestDelete(t *testing.T) {
 			existingPodCliques := createDefaultPodCliques(pgsObjMeta, "howl", tc.numExistingPodCliques)
 			// Create a fake client with PodCliques
 			cl := testutils.CreateFakeClientForObjectsMatchingLabels(tc.deleteError, nil, testPGSNamespace, grovecorev1alpha1.SchemeGroupVersion.WithKind("PodClique"), getPodCliqueSelectorLabels(pgsObjMeta), existingPodCliques...)
-			operator := New(cl, groveclientscheme.Scheme)
+			operator := New(cl, groveclientscheme.Scheme, record.NewFakeRecorder(10))
 			err := operator.Delete(context.Background(), logr.Discard(), pgsObjMeta)
 			if tc.expectedError != nil {
 				testutils.CheckGroveError(t, tc.expectedError, err)

--- a/operator/internal/component/podgangset/podgang/podgang.go
+++ b/operator/internal/component/podgangset/podgang/podgang.go
@@ -31,6 +31,7 @@ import (
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -47,15 +48,17 @@ const (
 )
 
 type _resource struct {
-	client client.Client
-	scheme *runtime.Scheme
+	client        client.Client
+	scheme        *runtime.Scheme
+	eventRecorder record.EventRecorder
 }
 
 // New creates a new instance of PodGang component operator.
-func New(client client.Client, scheme *runtime.Scheme) component.Operator[grovecorev1alpha1.PodGangSet] {
+func New(client client.Client, scheme *runtime.Scheme, eventRecorder record.EventRecorder) component.Operator[grovecorev1alpha1.PodGangSet] {
 	return &_resource{
-		client: client,
-		scheme: scheme,
+		client:        client,
+		scheme:        scheme,
+		eventRecorder: eventRecorder,
 	}
 }
 

--- a/operator/internal/component/podgangset/podgang/syncflow.go
+++ b/operator/internal/component/podgangset/podgang/syncflow.go
@@ -437,14 +437,14 @@ func (r _resource) createOrUpdatePodGang(sc *syncContext, pgInfo podGangInfo) er
 		return r.buildResource(sc.pgs, pgInfo, pg)
 	})
 	if err != nil {
-		r.eventRecorder.Eventf(sc.pgs, corev1.EventTypeWarning, groveevents.ReasonPodGangCreateOrUpdateFailed, "Error Creating/Updating PodGang %v: %v", pgObjectKey, err)
+		r.eventRecorder.Eventf(sc.pgs, corev1.EventTypeWarning, groveevents.ReasonPodGangCreationOrUpdationFailed, "Error Creating/Updating PodGang %v: %v", pgObjectKey, err)
 		return groveerr.WrapError(err,
 			errCodeCreateOrPatchPodGang,
 			component.OperationSync,
 			fmt.Sprintf("Failed to CreateOrPatch PodGang %v", pgObjectKey),
 		)
 	}
-	r.eventRecorder.Eventf(sc.pgs, corev1.EventTypeNormal, groveevents.ReasonPodGangCreateOrUpdateSuccessful, "Created/Updated PodGang %v", pgObjectKey)
+	r.eventRecorder.Eventf(sc.pgs, corev1.EventTypeNormal, groveevents.ReasonPodGangCreationOrUpdationSuccessful, "Created/Updated PodGang %v", pgObjectKey)
 	sc.logger.Info("Triggered CreateOrPatch of PodGang", "objectKey", pgObjectKey)
 	return nil
 }

--- a/operator/internal/component/podgangset/podgang/syncflow.go
+++ b/operator/internal/component/podgangset/podgang/syncflow.go
@@ -21,10 +21,12 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strconv"
 
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	"github.com/NVIDIA/grove/operator/internal/component"
+	groveevents "github.com/NVIDIA/grove/operator/internal/component/events"
 	componentutils "github.com/NVIDIA/grove/operator/internal/component/utils"
 	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
 	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
@@ -360,12 +362,14 @@ func (r _resource) deleteExcessPodGangs(sc *syncContext) error {
 		pg := emptyPodGang(pgObjectKey)
 		sc.logger.Info("Delete excess PodGang", "objectKey", client.ObjectKeyFromObject(pg))
 		if err := client.IgnoreNotFound(r.client.Delete(sc.ctx, pg)); err != nil {
+			r.eventRecorder.Eventf(sc.pgs, corev1.EventTypeWarning, groveevents.ReasonPodGangDeletionFailed, "Error deleting PodGang %v: %v", pgObjectKey, err)
 			return groveerr.WrapError(err,
 				errCodeDeleteExcessPodGang,
 				component.OperationSync,
 				fmt.Sprintf("failed to delete PodGang %v", pgObjectKey),
 			)
 		}
+		r.eventRecorder.Eventf(sc.pgs, corev1.EventTypeNormal, groveevents.ReasonPodGangDeletionSuccessful, "Deleted PodGang %v", pgObjectKey)
 		sc.deletedPodGangNames = append(sc.deletedPodGangNames, podGangToDelete)
 		sc.logger.Info("Triggered delete of excess PodGang", "objectKey", client.ObjectKeyFromObject(pg))
 	}
@@ -433,12 +437,14 @@ func (r _resource) createOrUpdatePodGang(sc *syncContext, pgInfo podGangInfo) er
 		return r.buildResource(sc.pgs, pgInfo, pg)
 	})
 	if err != nil {
+		r.eventRecorder.Eventf(sc.pgs, corev1.EventTypeWarning, groveevents.ReasonPodGangCreateOrUpdateFailed, "Error Creating/Updating PodGang %v: %v", pgObjectKey, err)
 		return groveerr.WrapError(err,
 			errCodeCreateOrPatchPodGang,
 			component.OperationSync,
 			fmt.Sprintf("Failed to CreateOrPatch PodGang %v", pgObjectKey),
 		)
 	}
+	r.eventRecorder.Eventf(sc.pgs, corev1.EventTypeNormal, groveevents.ReasonPodGangCreateOrUpdateSuccessful, "Created/Updated PodGang %v", pgObjectKey)
 	sc.logger.Info("Triggered CreateOrPatch of PodGang", "objectKey", pgObjectKey)
 	return nil
 }
@@ -450,6 +456,11 @@ func createPodGroupsForPodGang(namespace string, pgInfo podGangInfo) []grovesche
 				Namespace: namespace,
 				Name:      associatedPodName,
 			}
+		})
+		// sorting the slice of NamespaceName. This prevents unnecessary updates to the PodGang resource if the only thing
+		// that is difference is the order of NamespaceNames.
+		sort.Slice(namespacedNames, func(i, j int) bool {
+			return namespacedNames[i].Name < namespacedNames[j].Name
 		})
 		return groveschedulerv1alpha1.PodGroup{
 			Name:          pclq.fqn,

--- a/operator/internal/component/podgangset/registry.go
+++ b/operator/internal/component/podgangset/registry.go
@@ -28,20 +28,21 @@ import (
 	"github.com/NVIDIA/grove/operator/internal/component/podgangset/service"
 	"github.com/NVIDIA/grove/operator/internal/component/podgangset/serviceaccount"
 
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // CreateOperatorRegistry initializes the operator registry for the PodGangSet reconciler.
-func CreateOperatorRegistry(mgr manager.Manager) component.OperatorRegistry[v1alpha1.PodGangSet] {
+func CreateOperatorRegistry(mgr manager.Manager, eventRecorder record.EventRecorder) component.OperatorRegistry[v1alpha1.PodGangSet] {
 	cl := mgr.GetClient()
 	reg := component.NewOperatorRegistry[v1alpha1.PodGangSet]()
-	reg.Register(component.KindPodClique, podclique.New(cl, mgr.GetScheme()))
+	reg.Register(component.KindPodClique, podclique.New(cl, mgr.GetScheme(), eventRecorder))
 	reg.Register(component.KindHeadlessService, service.New(cl, mgr.GetScheme()))
 	reg.Register(component.KindRole, role.New(cl, mgr.GetScheme()))
 	reg.Register(component.KindRoleBinding, rolebinding.New(cl, mgr.GetScheme()))
 	reg.Register(component.KindServiceAccount, serviceaccount.New(cl, mgr.GetScheme()))
-	reg.Register(component.KindPodCliqueScalingGroup, podcliquescalinggroup.New(cl, mgr.GetScheme()))
+	reg.Register(component.KindPodCliqueScalingGroup, podcliquescalinggroup.New(cl, mgr.GetScheme(), eventRecorder))
 	reg.Register(component.KindHorizontalPodAutoscaler, hpa.New(cl, mgr.GetScheme()))
-	reg.Register(component.KindPodGang, podgang.New(cl, mgr.GetScheme()))
+	reg.Register(component.KindPodGang, podgang.New(cl, mgr.GetScheme(), eventRecorder))
 	return reg
 }

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -45,7 +45,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 	podCategories := k8sutils.CategorizePodsByConditionType(logger, existingPods)
 
 	// mutate PodClique Status Replicas, ReadyReplicas, ScheduleGatedReplicas and UpdatedReplicas.
-	mutateStatusReplicaCounts(pclq, podCategories)
+	mutateStatusReplicaCounts(pclq, podCategories, len(existingPods))
 
 	// mutate the conditions only if the PodClique has been successfully reconciled at least once.
 	// This prevents prematurely setting incorrect conditions.
@@ -71,9 +71,9 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 	return ctrlcommon.ContinueReconcile()
 }
 
-func mutateStatusReplicaCounts(pclq *grovecorev1alpha1.PodClique, podCategories map[corev1.PodConditionType][]*corev1.Pod) {
+func mutateStatusReplicaCounts(pclq *grovecorev1alpha1.PodClique, podCategories map[corev1.PodConditionType][]*corev1.Pod, numExistingPods int) {
 	// mutate the PCLQ status with current number of schedule gated, ready pods and updated pods.
-	numNonTerminatingPods := pclq.Spec.Replicas - int32(len(podCategories[k8sutils.TerminatingPod]))
+	numNonTerminatingPods := int32(numExistingPods - len(podCategories[k8sutils.TerminatingPod]))
 	pclq.Status.Replicas = numNonTerminatingPods
 	pclq.Status.ReadyReplicas = int32(len(podCategories[corev1.PodReady]))
 	pclq.Status.ScheduleGatedReplicas = int32(len(podCategories[k8sutils.ScheduleGatedPod]))

--- a/operator/internal/controller/podclique/reconcilestatus.go
+++ b/operator/internal/controller/podclique/reconcilestatus.go
@@ -19,7 +19,6 @@ package podclique
 import (
 	"context"
 	"fmt"
-
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	componentutils "github.com/NVIDIA/grove/operator/internal/component/utils"
 	ctrlcommon "github.com/NVIDIA/grove/operator/internal/controller/common"
@@ -46,15 +45,16 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 	podCategories := k8sutils.CategorizePodsByConditionType(logger, existingPods)
 
 	// mutate PodClique Status Replicas, ReadyReplicas, ScheduleGatedReplicas and UpdatedReplicas.
-	r.mutateStatusReplicaCounts(pclq, podCategories)
+	mutateStatusReplicaCounts(pclq, podCategories)
 
-	// mutate the grovecorev1alpha1.ConditionTypeMinAvailableBreached condition based on the number of ready pods.
-	// Only do this if the PodClique has been successfully reconciled at least once. This prevents prematurely setting
-	// incorrect MinAvailable breached condition.
+	// mutate the conditions only if the PodClique has been successfully reconciled at least once.
+	// This prevents prematurely setting incorrect conditions.
 	if pclq.Status.ObservedGeneration != nil {
+		mutatePodCliqueScheduledCondition(pclq)
 		mutateMinAvailableBreachedCondition(pclq,
 			len(podCategories[k8sutils.PodHasAtleastOneContainerWithNonZeroExitCode]),
 			len(podCategories[k8sutils.PodStartedButNotReady]))
+
 	}
 
 	// mutate the selector that will be used by an autoscaler.
@@ -71,12 +71,13 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 	return ctrlcommon.ContinueReconcile()
 }
 
-func (r *Reconciler) mutateStatusReplicaCounts(pclq *grovecorev1alpha1.PodClique, podCategories map[corev1.PodConditionType][]*corev1.Pod) {
+func mutateStatusReplicaCounts(pclq *grovecorev1alpha1.PodClique, podCategories map[corev1.PodConditionType][]*corev1.Pod) {
 	// mutate the PCLQ status with current number of schedule gated, ready pods and updated pods.
 	numNonTerminatingPods := pclq.Spec.Replicas - int32(len(podCategories[k8sutils.TerminatingPod]))
 	pclq.Status.Replicas = numNonTerminatingPods
 	pclq.Status.ReadyReplicas = int32(len(podCategories[corev1.PodReady]))
 	pclq.Status.ScheduleGatedReplicas = int32(len(podCategories[k8sutils.ScheduleGatedPod]))
+	pclq.Status.ScheduledReplicas = int32(len(podCategories[corev1.PodScheduled]))
 	// TODO: change this when rolling update is implemented
 	pclq.Status.UpdatedReplicas = numNonTerminatingPods
 }
@@ -107,12 +108,25 @@ func mutateMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, numN
 }
 
 func computeMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, numPodsHavingAtleastOneContainerWithNonZeroExitCode, numPodsStartedButNotReady int) metav1.Condition {
-	readyOrStartingPods := int(pclq.Status.Replicas) - numPodsHavingAtleastOneContainerWithNonZeroExitCode - numPodsStartedButNotReady
 	// dereferencing is considered safe as MinAvailable will always be set by the defaulting webhook. If this changes in the future,
 	// make sure that you check for nil explicitly.
 	minAvailable := int(*pclq.Spec.MinAvailable)
+	scheduledReplicas := int(pclq.Status.ScheduledReplicas)
 	now := metav1.Now()
 
+	// If the number of scheduled pods is less than the minimum available, then minAvailable is not considered as breached.
+	// Consider a case where none of the PodCliques have been scheduled yet, then it should not cause the PodGang to be recreated all the time.
+	if scheduledReplicas < minAvailable {
+		return metav1.Condition{
+			Type:               grovecorev1alpha1.ConditionTypeMinAvailableBreached,
+			Status:             metav1.ConditionFalse,
+			Reason:             grovecorev1alpha1.ConditionReasonInsufficientScheduledPods,
+			Message:            fmt.Sprintf("Insufficient scheduled pods. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
+			LastTransitionTime: now,
+		}
+	}
+
+	readyOrStartingPods := scheduledReplicas - numPodsHavingAtleastOneContainerWithNonZeroExitCode - numPodsStartedButNotReady
 	// pclq.Status.ReadyReplicas do not account for Pods which are not yet ready and are in the process of starting/initializing.
 	// This allows sufficient time specially for pods that have long-running init containers or slow-to-start main containers.
 	// Therefore, we take Pods that are NotReady and at least one of their containers have exited with a non-zero exit code. Kubelet
@@ -121,7 +135,7 @@ func computeMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, num
 		return metav1.Condition{
 			Type:               grovecorev1alpha1.ConditionTypeMinAvailableBreached,
 			Status:             metav1.ConditionTrue,
-			Reason:             "InsufficientReadyPods",
+			Reason:             grovecorev1alpha1.ConditionReasonInsufficientReadyPods,
 			Message:            fmt.Sprintf("Insufficient ready or starting pods. expected at least: %d, found: %d", minAvailable, readyOrStartingPods),
 			LastTransitionTime: now,
 		}
@@ -129,8 +143,35 @@ func computeMinAvailableBreachedCondition(pclq *grovecorev1alpha1.PodClique, num
 	return metav1.Condition{
 		Type:               grovecorev1alpha1.ConditionTypeMinAvailableBreached,
 		Status:             metav1.ConditionFalse,
-		Reason:             "SufficientReadyPods",
-		Message:            fmt.Sprintf("Sufficient ready or starting pods found. expected at least: %d, found: %d", minAvailable, readyOrStartingPods),
+		Reason:             grovecorev1alpha1.ConditionReasonSufficientReadyPods,
+		Message:            fmt.Sprintf("Either sufficient ready or starting pods found. expected at least: %d, found: %d", minAvailable, readyOrStartingPods),
+		LastTransitionTime: now,
+	}
+}
+
+func mutatePodCliqueScheduledCondition(pclq *grovecorev1alpha1.PodClique) {
+	newCondition := computePodCliqueScheduledCondition(pclq)
+	if k8sutils.HasConditionChanged(pclq.Status.Conditions, newCondition) {
+		meta.SetStatusCondition(&pclq.Status.Conditions, newCondition)
+	}
+}
+
+func computePodCliqueScheduledCondition(pclq *grovecorev1alpha1.PodClique) metav1.Condition {
+	now := metav1.Now()
+	if pclq.Status.ScheduledReplicas < *pclq.Spec.MinAvailable {
+		return metav1.Condition{
+			Type:               grovecorev1alpha1.ConditionTypePodCliqueScheduled,
+			Status:             metav1.ConditionFalse,
+			Reason:             grovecorev1alpha1.ConditionReasonInsufficientScheduledPods,
+			Message:            fmt.Sprintf("Insufficient scheduled pods. expected at least: %d, found: %d", *pclq.Spec.MinAvailable, pclq.Status.ScheduledReplicas),
+			LastTransitionTime: now,
+		}
+	}
+	return metav1.Condition{
+		Type:               grovecorev1alpha1.ConditionTypePodCliqueScheduled,
+		Status:             metav1.ConditionTrue,
+		Reason:             grovecorev1alpha1.ConditionReasonSufficientScheduledPods,
+		Message:            fmt.Sprintf("Sufficient scheduled pods found. expected at least: %d, found: %d", *pclq.Spec.MinAvailable, pclq.Status.ScheduledReplicas),
 		LastTransitionTime: now,
 	}
 }

--- a/operator/internal/controller/podclique/register.go
+++ b/operator/internal/controller/podclique/register.go
@@ -18,6 +18,7 @@ package podclique
 
 import (
 	"context"
+	"github.com/NVIDIA/grove/operator/internal/utils"
 	"strings"
 
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
@@ -132,11 +133,7 @@ func hasReadyConditionChanged(oldPodConditions, newPodConditions []corev1.PodCon
 func hasLastTerminationStateChanged(oldContainerStatuses []corev1.ContainerStatus, newContainerStatuses []corev1.ContainerStatus) bool {
 	oldErroneousContainerStatus := k8sutils.GetContainerStatusIfTerminatedErroneously(oldContainerStatuses)
 	newErroneousContainerStatus := k8sutils.GetContainerStatusIfTerminatedErroneously(newContainerStatuses)
-	if (oldErroneousContainerStatus == nil && newErroneousContainerStatus != nil) ||
-		(oldErroneousContainerStatus != nil && newErroneousContainerStatus == nil) {
-		return true
-	}
-	return false
+	return utils.OnlyOneIsNil(oldErroneousContainerStatus, newErroneousContainerStatus)
 }
 
 func hasStartedAndReadyChangedForAnyContainer(oldContainerStatuses []corev1.ContainerStatus, newContainerStatuses []corev1.ContainerStatus) bool {

--- a/operator/internal/controller/podclique/register.go
+++ b/operator/internal/controller/podclique/register.go
@@ -22,6 +22,7 @@ import (
 
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	grovectrlutils "github.com/NVIDIA/grove/operator/internal/controller/utils"
+	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
 
 	groveschedulerv1alpha1 "github.com/NVIDIA/grove/scheduler/api/core/v1alpha1"
 	"github.com/samber/lo"
@@ -109,7 +110,10 @@ func hasPodStatusChanged(updateEvent event.UpdateEvent) bool {
 	if !oldOk || !newOk {
 		return false
 	}
-	return hasReadyConditionChanged(oldPod.Status.Conditions, newPod.Status.Conditions)
+	return hasReadyConditionChanged(oldPod.Status.Conditions, newPod.Status.Conditions) ||
+		hasLastTerminationStateChanged(oldPod.Status.InitContainerStatuses, newPod.Status.InitContainerStatuses) ||
+		hasLastTerminationStateChanged(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses) ||
+		hasStartedAndReadyChangedForAnyContainer(oldPod.Status.ContainerStatuses, newPod.Status.ContainerStatuses)
 }
 
 func hasReadyConditionChanged(oldPodConditions, newPodConditions []corev1.PodCondition) bool {
@@ -123,6 +127,32 @@ func hasReadyConditionChanged(oldPodConditions, newPodConditions []corev1.PodCon
 	oldPodReady := oldOk && oldPodReadyCondition.Status == corev1.ConditionTrue
 	newPodReady := newOk && newPodReadyCondition.Status == corev1.ConditionTrue
 	return oldPodReady != newPodReady
+}
+
+func hasLastTerminationStateChanged(oldContainerStatuses []corev1.ContainerStatus, newContainerStatuses []corev1.ContainerStatus) bool {
+	oldErroneousContainerStatus := k8sutils.GetContainerStatusIfTerminatedErroneously(oldContainerStatuses)
+	newErroneousContainerStatus := k8sutils.GetContainerStatusIfTerminatedErroneously(newContainerStatuses)
+	if (oldErroneousContainerStatus == nil && newErroneousContainerStatus != nil) ||
+		(oldErroneousContainerStatus != nil && newErroneousContainerStatus == nil) {
+		return true
+	}
+	return false
+}
+
+func hasStartedAndReadyChangedForAnyContainer(oldContainerStatuses []corev1.ContainerStatus, newContainerStatuses []corev1.ContainerStatus) bool {
+	for _, oldContainerStatus := range oldContainerStatuses {
+		matchingNewContainerStatus, ok := lo.Find(newContainerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+			return oldContainerStatus.Name == containerStatus.Name
+		})
+		if !ok {
+			return true
+		}
+		if matchingNewContainerStatus.Ready != oldContainerStatus.Ready ||
+			matchingNewContainerStatus.Started != oldContainerStatus.Started {
+			return true
+		}
+	}
+	return false
 }
 
 // mapPodGangToPCLQs maps a PodGang to one or more reconcile.Request(s) for its constituent PodClique's.
@@ -155,7 +185,7 @@ func extractPCLQNameFromPodName(podName string) string {
 func podGangPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc:  func(_ event.CreateEvent) bool { return true },
-		DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
+		DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
 		UpdateFunc:  func(_ event.UpdateEvent) bool { return true },
 		GenericFunc: func(_ event.GenericEvent) bool { return false },
 	}

--- a/operator/internal/controller/podcliquescalinggroup/reconciler.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconciler.go
@@ -42,19 +42,18 @@ type Reconciler struct {
 
 // NewReconciler creates a new instance of the PodClique Reconciler.
 func NewReconciler(mgr ctrl.Manager, controllerCfg groveconfigv1alpha1.PodCliqueScalingGroupControllerConfiguration) *Reconciler {
+	eventRecorder := mgr.GetEventRecorderFor(controllerName)
 	return &Reconciler{
 		config:                  controllerCfg,
 		client:                  mgr.GetClient(),
-		reconcileStatusRecorder: ctrlcommon.NewReconcileStatusRecorder(mgr.GetClient(), mgr.GetEventRecorderFor(controllerName)),
-		operatorRegistry:        pcsgcomponent.CreateOperatorRegistry(mgr, nil),
+		reconcileStatusRecorder: ctrlcommon.NewReconcileStatusRecorder(mgr.GetClient(), eventRecorder),
+		operatorRegistry:        pcsgcomponent.CreateOperatorRegistry(mgr, eventRecorder),
 	}
 }
 
 // Reconcile reconciles a PodCliqueScalingGroup resource.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := ctrllogger.FromContext(ctx).
-		WithName(controllerName).
-		WithValues("pcsg-name", req.Name, "pcsg-namespace", req.Namespace)
+	logger := ctrllogger.FromContext(ctx).WithName(controllerName)
 
 	pcsg := &grovecorev1alpha1.PodCliqueScalingGroup{}
 	if result := ctrlutils.GetPodCliqueScalingGroup(ctx, r.client, logger, req.NamespacedName, pcsg); ctrlcommon.ShortCircuitReconcileFlow(result) {

--- a/operator/internal/controller/podcliquescalinggroup/reconcilespec.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilespec.go
@@ -31,7 +31,6 @@ import (
 )
 
 func (r *Reconciler) reconcileSpec(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) ctrlcommon.ReconcileStepResult {
-	rLog := logger.WithValues("operation", "spec-reconcile")
 	reconcileStepFns := []ctrlcommon.ReconcileStepFn[grovecorev1alpha1.PodCliqueScalingGroup]{
 		r.ensureFinalizer,
 		r.recordReconcileStart,
@@ -41,7 +40,7 @@ func (r *Reconciler) reconcileSpec(ctx context.Context, logger logr.Logger, pcsg
 	}
 
 	for _, fn := range reconcileStepFns {
-		if stepResult := fn(ctx, rLog, pcsg); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
+		if stepResult := fn(ctx, logger, pcsg); ctrlcommon.ShortCircuitReconcileFlow(stepResult) {
 			return r.recordIncompleteReconcile(ctx, logger, pcsg, &stepResult)
 		}
 	}

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -34,21 +34,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// defaultPCSGMinAvailable is the default value of minAvailable for PCSG. Currently, this is not configurable via the API.
-// Once it is made configurable then this constant is no longer required and should be removed.
-const defaultPCSGMinAvailable = 1
-
 func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) ctrlcommon.ReconcileStepResult {
-	pcsg.Status.Replicas = pcsg.Spec.Replicas
-
 	pgs, err := componentutils.GetOwnerPodGangSet(ctx, r.client, pcsg.ObjectMeta)
 	if err != nil {
 		return ctrlcommon.ReconcileWithErrors("failed to get owner PodGangSet", err)
 	}
 
-	if err = r.mutateMinAvailableBreachedCondition(ctx, logger, pgs.Name, pcsg); err != nil {
-		logger.Error(err, "failed to mutate minAvailable breachedCondition")
-		return ctrlcommon.ReconcileWithErrors("failed to mutate minAvailable breachedCondition", err)
+	pclqsPerPCSGReplica, err := r.getPodCliquesPerPCSGReplica(ctx, pgs.Name, client.ObjectKeyFromObject(pcsg))
+	if err != nil {
+		return ctrlcommon.ReconcileWithErrors(fmt.Sprintf("failed to list PodCliques for PodCliqueScalingGroup: %q", client.ObjectKeyFromObject(pcsg)), err)
+	}
+
+	if pcsg.Status.ObservedGeneration != nil {
+		mutateReplicas(logger, pcsg, pclqsPerPCSGReplica)
+		mutateMinAvailableBreachedCondition(logger, pcsg, pclqsPerPCSGReplica)
 	}
 
 	if err = mutateSelector(pgs, pcsg); err != nil {
@@ -56,104 +55,97 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, logger logr.Logger, pc
 		return ctrlcommon.ReconcileWithErrors("failed to update selector for PodCliqueScalingGroup", err)
 	}
 
-	if err := r.client.Status().Update(ctx, pcsg); err != nil {
+	if err = r.client.Status().Update(ctx, pcsg); err != nil {
 		return ctrlcommon.ReconcileWithErrors("failed to update the status with label selector and replicas", err)
 	}
 
 	return ctrlcommon.ContinueReconcile()
 }
 
-func (r *Reconciler) mutateMinAvailableBreachedCondition(ctx context.Context, logger logr.Logger, pgsName string, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) error {
-	newCondition, err := r.computeMinAvailableBreachedCondition(ctx, logger, pgsName, pcsg)
-	if err != nil {
-		return err
+func mutateReplicas(logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pclqsPerPCSGReplica map[string][]grovecorev1alpha1.PodClique) {
+	pcsg.Status.Replicas = pcsg.Spec.Replicas
+	var scheduledReplicas int32
+	for pcsgReplicaIndex, pclqs := range pclqsPerPCSGReplica {
+		isScheduled := lo.Reduce(pclqs, func(agg bool, pclq grovecorev1alpha1.PodClique, _ int) bool {
+			return agg && k8sutils.IsConditionTrue(pclq.Status.Conditions, grovecorev1alpha1.ConditionTypePodCliqueScheduled)
+		}, true)
+		if isScheduled {
+			scheduledReplicas++
+		}
+		logger.Info("PodCliqueScalingGroup replica scheduled status", "pcsgReplicaIndex", pcsgReplicaIndex, "isScheduled", isScheduled)
 	}
-	if k8sutils.HasConditionChanged(pcsg.Status.Conditions, *newCondition) {
-		meta.SetStatusCondition(&pcsg.Status.Conditions, *newCondition)
-	}
-	return nil
+	pcsg.Status.ScheduledReplicas = scheduledReplicas
 }
 
-func (r *Reconciler) computeMinAvailableBreachedCondition(ctx context.Context, logger logr.Logger, pgsName string, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) (*metav1.Condition, error) {
+func mutateMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pclqsPerPCSGReplica map[string][]grovecorev1alpha1.PodClique) {
+	newCondition := computeMinAvailableBreachedCondition(logger, pcsg, pclqsPerPCSGReplica)
+	if k8sutils.HasConditionChanged(pcsg.Status.Conditions, newCondition) {
+		meta.SetStatusCondition(&pcsg.Status.Conditions, newCondition)
+	}
+}
+
+func computeMinAvailableBreachedCondition(logger logr.Logger, pcsg *grovecorev1alpha1.PodCliqueScalingGroup, pclqsPerPCSGReplica map[string][]grovecorev1alpha1.PodClique) metav1.Condition {
+	minAvailable := int(*pcsg.Spec.MinAvailable)
+	scheduledReplicas := int(pcsg.Status.ScheduledReplicas)
+	if scheduledReplicas < minAvailable {
+		return metav1.Condition{
+			Type:    grovecorev1alpha1.ConditionTypeMinAvailableBreached,
+			Status:  metav1.ConditionFalse,
+			Reason:  grovecorev1alpha1.ConditionReasonInsufficientScheduledPCSGReplicas,
+			Message: fmt.Sprintf("Insufficient scheduled replicas. expected at least: %d, found: %d", minAvailable, scheduledReplicas),
+		}
+	}
+	minAvailableBreachedReplicas := computeMinAvailableBreachedReplicas(logger, pclqsPerPCSGReplica)
+	readyReplicas := scheduledReplicas - minAvailableBreachedReplicas
+	if readyReplicas < minAvailable {
+		return metav1.Condition{
+			Type:    grovecorev1alpha1.ConditionTypeMinAvailableBreached,
+			Status:  metav1.ConditionTrue,
+			Reason:  grovecorev1alpha1.ConditionReasonInsufficientReadyPCSGReplicas,
+			Message: fmt.Sprintf("Insufficient PodCliqueScalingGroup ready replicas, expected at least: %d, found: %d", minAvailable, readyReplicas),
+		}
+	}
+	return metav1.Condition{
+		Type:    grovecorev1alpha1.ConditionTypeMinAvailableBreached,
+		Status:  metav1.ConditionFalse,
+		Reason:  grovecorev1alpha1.ConditionReasonSufficientReadyPCSGReplicas,
+		Message: fmt.Sprintf("Sufficient PodCliqueScalingGroup ready replicas, expected at least: %d, found: %d", minAvailable, readyReplicas),
+	}
+}
+
+func computeMinAvailableBreachedReplicas(logger logr.Logger, pclqsPerPCSGReplica map[string][]grovecorev1alpha1.PodClique) int {
+	var breachedReplicas int
+	for pcsgReplicaIndex, pclqs := range pclqsPerPCSGReplica {
+		isMinAvailableBreached := lo.Reduce(pclqs, func(agg bool, pclq grovecorev1alpha1.PodClique, _ int) bool {
+			return agg || k8sutils.IsConditionTrue(pclq.Status.Conditions, grovecorev1alpha1.ConditionTypeMinAvailableBreached)
+		}, false)
+		if isMinAvailableBreached {
+			breachedReplicas++
+		}
+		logger.Info("PodCliqueScalingGroup replica has MinAvailableBreached condition set to true", "pcsgReplicaIndex", pcsgReplicaIndex, "isMinAvailableBreached", isMinAvailableBreached)
+	}
+	return breachedReplicas
+}
+
+func (r *Reconciler) getPodCliquesPerPCSGReplica(ctx context.Context, pgsName string, pcsgObjKey client.ObjectKey) (map[string][]grovecorev1alpha1.PodClique, error) {
 	selectorLabels := lo.Assign(
 		k8sutils.GetDefaultLabelsForPodGangSetManagedResources(pgsName),
 		map[string]string{
-			grovecorev1alpha1.LabelPodCliqueScalingGroup: pcsg.Name,
+			grovecorev1alpha1.LabelPodCliqueScalingGroup: pcsgObjKey.Name,
 			grovecorev1alpha1.LabelComponentKey:          component.NamePCSGPodClique,
 		},
 	)
-	pcsgPCLQs, err := componentutils.GetPCLQsByOwner(ctx,
+	pclqs, err := componentutils.GetPCLQsByOwner(ctx,
 		r.client,
 		grovecorev1alpha1.PodCliqueScalingGroupKind,
-		client.ObjectKeyFromObject(pcsg),
+		pcsgObjKey,
 		selectorLabels,
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	// group PodCliques per PodCliqueScalingGroup
-	pcsgReplicaPCLQs := componentutils.GroupPCLQsByPCSGReplicaIndex(pcsgPCLQs)
-	minAvailableBreachedPCSGReplicaIndexes := make([]string, 0, pcsg.Spec.Replicas)
-	var atleastOnePCSGReplicaIsUnknown bool
-	for pcsgReplicaIndex, pclqs := range pcsgReplicaPCLQs {
-		pcsgReplicaCondStatus := computeMinAvailableBreachedStatusForPSGReplica(logger, pcsgReplicaIndex, pclqs)
-		logger.Info("MinAvailableBreached condition status for PCSG replica", "pcsgReplicaIndex", pcsgReplicaIndex, "conditionStatus", pcsgReplicaCondStatus)
-		switch pcsgReplicaCondStatus {
-		case metav1.ConditionTrue:
-			minAvailableBreachedPCSGReplicaIndexes = append(minAvailableBreachedPCSGReplicaIndexes, pcsgReplicaIndex)
-		case metav1.ConditionUnknown:
-			atleastOnePCSGReplicaIsUnknown = true
-		}
-	}
-
-	numReadyPCSGReplicas := int(pcsg.Spec.Replicas) - len(minAvailableBreachedPCSGReplicaIndexes)
-	if numReadyPCSGReplicas < defaultPCSGMinAvailable {
-		return &metav1.Condition{
-			Type:    grovecorev1alpha1.ConditionTypeMinAvailableBreached,
-			Status:  metav1.ConditionTrue,
-			Reason:  "InsufficientReadyPodCliqueScalingGroupReplicas",
-			Message: fmt.Sprintf("Insufficient PodCliqueScalingGroup replicas, expected at least: %d, found: %d", defaultPCSGMinAvailable, numReadyPCSGReplicas),
-		}, nil
-	}
-
-	if atleastOnePCSGReplicaIsUnknown {
-		return &metav1.Condition{
-			Type:    grovecorev1alpha1.ConditionTypeMinAvailableBreached,
-			Status:  metav1.ConditionUnknown,
-			Reason:  "PodCliqueScalingGroupReplicasInUnknownState",
-			Message: "PodCliqueScalingGroup replicas in unknown state",
-		}, nil
-	}
-
-	return &metav1.Condition{
-		Type:    grovecorev1alpha1.ConditionTypeMinAvailableBreached,
-		Status:  metav1.ConditionFalse,
-		Reason:  "SufficientReadyPodCliqueScalingGroupReplicas",
-		Message: fmt.Sprintf("Sufficient PodCliqueScalingGroup replicas, expected at least: %d, found: %d", defaultPCSGMinAvailable, numReadyPCSGReplicas),
-	}, nil
-}
-
-func computeMinAvailableBreachedStatusForPSGReplica(logger logr.Logger, pcsgReplicaIndex string, pclqs []grovecorev1alpha1.PodClique) metav1.ConditionStatus {
-	var atleastOneStatusIsUnknown bool
-	for _, pclq := range pclqs {
-		logger.Info("MinAvailable condition status for PCLQ", "pclq", client.ObjectKeyFromObject(&pclq), "status", k8sutils.GetConditionStatus(pclq.Status.Conditions, grovecorev1alpha1.ConditionTypeMinAvailableBreached))
-		if k8sutils.IsConditionTrue(pclq.Status.Conditions, grovecorev1alpha1.ConditionTypeMinAvailableBreached) {
-			logger.Info("PodClique has MinAvailableBreached condition set to true", "pcsgReplicaIndex", pcsgReplicaIndex, "pclq", client.ObjectKeyFromObject(&pclq))
-			return metav1.ConditionTrue
-		}
-		if k8sutils.IsResourceTerminating(pclq.ObjectMeta) {
-			atleastOneStatusIsUnknown = true
-			logger.Info("PCLQ is marked for termination, cannot determine the MinAvailableBreached condition status, assuming Unknown", "pcsgReplicaIndex", pcsgReplicaIndex, "pclq", client.ObjectKeyFromObject(&pclq))
-			continue
-		}
-		if pclq.Status.Conditions == nil ||
-			k8sutils.IsConditionUnknown(pclq.Status.Conditions, grovecorev1alpha1.ConditionTypeMinAvailableBreached) {
-			logger.Info("PodClique has MinAvailableBreached condition is either not set yet or is set to Unknown", "pcsgReplicaIndex", pcsgReplicaIndex, "pclq", client.ObjectKeyFromObject(&pclq))
-			atleastOneStatusIsUnknown = true
-		}
-	}
-	return lo.Ternary(atleastOneStatusIsUnknown, metav1.ConditionUnknown, metav1.ConditionFalse)
+	pclqsPerPCSGReplica := componentutils.GroupPCLQsByPCSGReplicaIndex(pclqs)
+	return pclqsPerPCSGReplica, nil
 }
 
 func mutateSelector(pgs *grovecorev1alpha1.PodGangSet, pcsg *grovecorev1alpha1.PodCliqueScalingGroup) error {

--- a/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
+++ b/operator/internal/controller/podcliquescalinggroup/reconcilestatus.go
@@ -102,7 +102,7 @@ func (r *Reconciler) computeMinAvailableBreachedCondition(ctx context.Context, l
 		switch pcsgReplicaCondStatus {
 		case metav1.ConditionTrue:
 			minAvailableBreachedPCSGReplicaIndexes = append(minAvailableBreachedPCSGReplicaIndexes, pcsgReplicaIndex)
-		case metav1.ConditionFalse:
+		case metav1.ConditionUnknown:
 			atleastOnePCSGReplicaIsUnknown = true
 		}
 	}

--- a/operator/internal/controller/podcliquescalinggroup/register.go
+++ b/operator/internal/controller/podcliquescalinggroup/register.go
@@ -136,17 +136,7 @@ func podCliquePredicate() predicate.Predicate {
 			return ctrlutils.IsManagedPodClique(deleteEvent.Object, grovecorev1alpha1.PodCliqueScalingGroupKind)
 		},
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {
-			return ctrlutils.IsManagedPodClique(updateEvent.ObjectOld, grovecorev1alpha1.PodCliqueScalingGroupKind) &&
-				hasPodCliqueReadyReplicasChanged(updateEvent)
+			return ctrlutils.IsManagedPodClique(updateEvent.ObjectOld, grovecorev1alpha1.PodCliqueScalingGroupKind)
 		},
 	}
-}
-
-func hasPodCliqueReadyReplicasChanged(updateEvent event.UpdateEvent) bool {
-	oldPCLQ, okOld := updateEvent.ObjectOld.(*grovecorev1alpha1.PodClique)
-	newPCLQ, okNew := updateEvent.ObjectNew.(*grovecorev1alpha1.PodClique)
-	if !okOld || !okNew {
-		return false
-	}
-	return oldPCLQ.Status.ReadyReplicas != newPCLQ.Status.ReadyReplicas
 }

--- a/operator/internal/controller/podgangset/reconciler.go
+++ b/operator/internal/controller/podgangset/reconciler.go
@@ -43,19 +43,18 @@ type Reconciler struct {
 
 // NewReconciler creates a new reconciler for PodGangSet.
 func NewReconciler(mgr ctrl.Manager, controllerCfg configv1alpha1.PodGangSetControllerConfiguration) *Reconciler {
+	eventRecorder := mgr.GetEventRecorderFor(controllerName)
 	return &Reconciler{
 		config:                  controllerCfg,
 		client:                  mgr.GetClient(),
-		reconcileStatusRecorder: ctrlcommon.NewReconcileStatusRecorder(mgr.GetClient(), mgr.GetEventRecorderFor(controllerName)),
-		operatorRegistry:        pgscomponent.CreateOperatorRegistry(mgr),
+		reconcileStatusRecorder: ctrlcommon.NewReconcileStatusRecorder(mgr.GetClient(), eventRecorder),
+		operatorRegistry:        pgscomponent.CreateOperatorRegistry(mgr, eventRecorder),
 	}
 }
 
 // Reconcile reconciles a PodGangSet resource.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := ctrllogger.FromContext(ctx).
-		WithName(controllerName).
-		WithValues("pgs-name", req.Name, "pgs-namespace", req.Namespace)
+	logger := ctrllogger.FromContext(ctx).WithName(controllerName)
 
 	pgs := &grovecorev1alpha1.PodGangSet{}
 	if result := ctrlutils.GetPodGangSet(ctx, r.client, logger, req.NamespacedName, pgs); ctrlcommon.ShortCircuitReconcileFlow(result) {

--- a/operator/internal/expect/expectations.go
+++ b/operator/internal/expect/expectations.go
@@ -187,7 +187,7 @@ func (s *ExpectationsStore) lowerExpectations(logger logr.Logger, controlleeKey 
 // getControlleeExpectationsKeyFunc creates a cache.KeyFunc required for the cache.Store
 // This function is internally used to fetch the ControlleeExpectations object by its key.
 func getControlleeExpectationsKeyFunc() cache.KeyFunc {
-	return func(obj interface{}) (string, error) {
+	return func(obj any) (string, error) {
 		if exp, ok := obj.(*ControlleeExpectations); ok {
 			return exp.key, nil
 		}

--- a/operator/internal/expect/expectations.go
+++ b/operator/internal/expect/expectations.go
@@ -1,0 +1,196 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package expect
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ControlleeKeyFunc is a key function used to create Controllee keys that are used to uniquely identify expectations that
+// are stored in the expectations store.
+var ControlleeKeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
+
+// ExpectationsStore is a cache where add and delete expectations are captured.
+// `controller-runtime` serves the read requests from an informer cache and will query the kube-apiserver
+// during startup or resyncs. The informer cache does not provide read-your-writes consistency which leads to stale
+// caches. Informer caches are eventually consistent but if your controller gets quick events then it is possible
+// that the controller operates on a stale state, thus leading to side effects which could include creation of adding
+// resource replicas or deletion of more then desired replicas of a resource.
+// NOTE: Expectations is an existing pattern already used in kubernetes.
+// See [ControllerExpectationsInterface]: https://github.com/kubernetes/kubernetes/blob/e6161070d4416f6d9c1ac9961029fdceef5c9286/pkg/controller/controller_utils.go#L157
+// where expectations are used to provide a barrier when reconciling resources. If the previous expectations are not fulfilled, or they have not yet expired
+// no further resource creation/deletion will be done.
+// This implementation takes inspiration from it but takes a different take on how resources are tracked.
+// We propose to not use expectations as a barrier but only as an additional in-memory store of expectations that help
+// the reconciler correctly compute the desired number of creates or deletes.
+// It also attempts to resolve the 2 issues that are listed in https://github.com/kubernetes/kubernetes/issues/129795#issuecomment-2657716713
+type ExpectationsStore struct {
+	cache.Store
+	mu sync.Mutex
+}
+
+// ControlleeExpectations tracks expectations for the reconciled/controlled resource.
+// It will track the object UIDs for expected creations and deletions.
+// NOTE: When creating a resource, UID of an object is only available post the Create call. It is expected that the
+// consumers will capture the expectations after every Create call. For deletes the UID is already available before the
+// call to delete is made.
+type ControlleeExpectations struct {
+	// key is the unique identifier for the resource for which expectations are captured.
+	key string
+	// uidsToDelete are the set of resource UIDs that are expected to be deleted.
+	uidsToDelete sets.Set[types.UID]
+	// uidsToAdd are the set of resource UIDs that are expected to be created.
+	uidsToAdd sets.Set[types.UID]
+}
+
+// NewExpectationsStore creates a new expectations store.
+func NewExpectationsStore() *ExpectationsStore {
+	return &ExpectationsStore{
+		Store: cache.NewStore(getControlleeExpectationsKeyFunc()),
+	}
+}
+
+// ExpectCreations records resource creation expectations for uids for a controlled resource identified by a controlleeKey.
+func (s *ExpectationsStore) ExpectCreations(logger logr.Logger, controlleeKey string, uids ...types.UID) error {
+	return s.createOrRaiseExpectations(logger, controlleeKey, uids, nil)
+}
+
+// ExpectDeletions records resource deletion expectations for uids for a controlled resource identified by a controlleeKey.
+func (s *ExpectationsStore) ExpectDeletions(logger logr.Logger, controlleeKey string, uids ...types.UID) error {
+	return s.createOrRaiseExpectations(logger, controlleeKey, nil, uids)
+}
+
+// ObserveDeletions lowers the delete expectations removing the uids passed.
+func (s *ExpectationsStore) ObserveDeletions(logger logr.Logger, controlleeKey string, uids ...types.UID) {
+	s.lowerExpectations(logger, controlleeKey, nil, uids)
+}
+
+// DeleteExpectations removes all expectations stored against a controlleeKey from the store.
+func (s *ExpectationsStore) DeleteExpectations(logger logr.Logger, controlleeKey string) error {
+	exp, exists, err := s.GetByKey(controlleeKey)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if err = s.Delete(exp); err != nil {
+			return fmt.Errorf("%w: could not delete expectations for controlleeKey %s", err, controlleeKey)
+		}
+	}
+	logger.Info("Successfully deleted expectations", "controlleeKey", controlleeKey)
+	return nil
+}
+
+// GetExpectations gets the recorded expectations against a controlleeKey.
+func (s *ExpectationsStore) GetExpectations(controlleeKey string) (*ControlleeExpectations, bool, error) {
+	exp, exists, err := s.GetByKey(controlleeKey)
+	if err != nil || !exists {
+		return nil, false, err
+	}
+	return exp.(*ControlleeExpectations), true, nil
+}
+
+// SyncExpectations allows the expectations store to sync up expectations against the existingUIDs.
+// Informer caches are either updated via watch events or via an explicit sync to the kube-apiserver. Thus, an informer
+// cache is a single source of truth. Consumers while computing pending work anyway need to make a LIST call which will
+// most probably hit the informer cache. This function removes the need to have `ObserveDeletion` and `ObserveCreation`
+// and there is no longer a need to reduce the expectations from within the event handlers. This function takes in
+// an existing resource type.UIDs as seen by the informer cache and removes the expectations that are no longer
+// valid in the store.
+func (s *ExpectationsStore) SyncExpectations(controlleeKey string, existingUIDs ...types.UID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if exp, exists, _ := s.GetExpectations(controlleeKey); exists {
+		// Remove the UIDs from `uidsToAdd` if the informer cache is already up-to-date and certain events have
+		// been missed/dropped by the watch resulting in missed calls to `CreationObserved`.
+		exp.uidsToAdd.Delete(existingUIDs...)
+		// Remove stale entries in `uidsToDelete` if the `existingUIDS` no longer has those UIDs.
+		staleUIDs := exp.uidsToDelete.Difference(sets.New(existingUIDs...))
+		exp.uidsToDelete.Delete(staleUIDs.UnsortedList()...)
+	}
+}
+
+// GetCreateExpectations is a convenience method which gives a slice of resource UIDs for which creation has not yet been synced
+// in the informer cache.
+func (s *ExpectationsStore) GetCreateExpectations(controlleeKey string) []types.UID {
+	if exp, exists, _ := s.GetExpectations(controlleeKey); exists {
+		return exp.uidsToAdd.UnsortedList()
+	}
+	return nil
+}
+
+// GetDeleteExpectations is a convenience method which gives a slice of resource UIDs for which deletion has not yet been synced
+// in the informer cache.
+func (s *ExpectationsStore) GetDeleteExpectations(controlleeKey string) []types.UID {
+	if exp, exists, _ := s.GetExpectations(controlleeKey); exists {
+		return exp.uidsToDelete.UnsortedList()
+	}
+	return nil
+}
+
+// createOrRaiseExpectations creates or raises create/delete expectations for the given controlleeKey.
+func (s *ExpectationsStore) createOrRaiseExpectations(logger logr.Logger, controlleeKey string, uidsToAdd, uidsToDelete []types.UID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	exp, exists, err := s.GetExpectations(controlleeKey)
+	if err != nil {
+		return fmt.Errorf("%w: could not capture expectations [uidsToAdd: %v, uidsTodelete:%v] for resource: %v", err, uidsToAdd, controlleeKey, controlleeKey)
+	}
+	if !exists {
+		exp = &ControlleeExpectations{
+			key:          controlleeKey,
+			uidsToAdd:    sets.New(uidsToAdd...),
+			uidsToDelete: sets.New(uidsToDelete...),
+		}
+		logger.Info("created expectations for controller resource", "controlleeKey", controlleeKey, "uidsToAdd", uidsToAdd, "uidsToDelete", uidsToDelete)
+	} else {
+		exp.uidsToAdd.Insert(uidsToAdd...)
+		// If there are UIDs in uidsToDelete that also have a presence in uidsToAdd then remove these UIDs from uidsToAdd
+		// as those add expectations are now no longer valid.
+		exp.uidsToAdd.Delete(uidsToDelete...)
+		exp.uidsToDelete.Insert(uidsToDelete...)
+		logger.Info("raised expectations for controller resource", "controlleeKey", controlleeKey, "uidsToAdd", uidsToAdd, "uidsToDelete", uidsToDelete)
+	}
+	return s.Add(exp)
+}
+
+// lowerExpectations lowers create/delete expectations for the given controlleeKey.
+func (s *ExpectationsStore) lowerExpectations(logger logr.Logger, controlleeKey string, addUIDs, deleteUIDs []types.UID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if exp, exists, _ := s.GetExpectations(controlleeKey); exists {
+		exp.uidsToAdd.Delete(addUIDs...)
+		exp.uidsToDelete.Delete(deleteUIDs...)
+		logger.Info("lowered expectations for controlled resource", "controlleeKey", controlleeKey, "addUIDs", addUIDs, "deleteUIDs", deleteUIDs)
+	}
+}
+
+// getControlleeExpectationsKeyFunc creates a cache.KeyFunc required for the cache.Store
+// This function is internally used to fetch the ControlleeExpectations object by its key.
+func getControlleeExpectationsKeyFunc() cache.KeyFunc {
+	return func(obj interface{}) (string, error) {
+		if exp, ok := obj.(*ControlleeExpectations); ok {
+			return exp.key, nil
+		}
+		return "", fmt.Errorf("could not find key for obj %#v", obj)
+	}
+}

--- a/operator/internal/expect/expectations_test.go
+++ b/operator/internal/expect/expectations_test.go
@@ -189,7 +189,8 @@ func TestSyncExpectations(t *testing.T) {
 		controlleeKey                 string
 		createExpectationUIDs         []types.UID
 		deleteExpectationsUIDs        []types.UID
-		existingUIDs                  []types.UID
+		existingNonTerminatingUIDs    []types.UID
+		existingTerminatingUIDs       []types.UID
 		createExpectationUIDsPostSync []types.UID
 		deleteExpectationUIDsPostSync []types.UID
 	}{
@@ -198,14 +199,24 @@ func TestSyncExpectations(t *testing.T) {
 			controlleeKey:                 controlleeKey,
 			createExpectationUIDs:         []types.UID{"1", "2"},
 			deleteExpectationsUIDs:        []types.UID{"3", "6"},
-			existingUIDs:                  []types.UID{"1", "3", "4", "7"},
+			existingNonTerminatingUIDs:    []types.UID{"1", "3", "4", "7"},
 			createExpectationUIDsPostSync: []types.UID{"2"},
 			deleteExpectationUIDsPostSync: []types.UID{"3"},
 		},
 		{
+			description:                   "should re-add terminating pods",
+			controlleeKey:                 controlleeKey,
+			createExpectationUIDs:         []types.UID{"1"},
+			deleteExpectationsUIDs:        []types.UID{},
+			existingNonTerminatingUIDs:    []types.UID{"2", "3"},
+			existingTerminatingUIDs:       []types.UID{"4", "5"},
+			createExpectationUIDsPostSync: []types.UID{"1"},
+			deleteExpectationUIDsPostSync: []types.UID{"4", "5"},
+		},
+		{
 			description:                   "should be a no-op when expectations do not exist",
 			controlleeKey:                 "does-not-exist",
-			existingUIDs:                  []types.UID{"1", "2"},
+			existingNonTerminatingUIDs:    []types.UID{"1", "2"},
 			createExpectationUIDsPostSync: []types.UID{},
 			deleteExpectationUIDsPostSync: []types.UID{},
 		},
@@ -215,7 +226,7 @@ func TestSyncExpectations(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			assert.NoError(t, initializeControlleeExpectations(expStore, tc.controlleeKey, tc.createExpectationUIDs, tc.deleteExpectationsUIDs))
-			expStore.SyncExpectations(tc.controlleeKey, tc.existingUIDs...)
+			expStore.SyncExpectations(tc.controlleeKey, tc.existingNonTerminatingUIDs, tc.existingTerminatingUIDs)
 			assert.ElementsMatch(t, tc.createExpectationUIDsPostSync, expStore.GetCreateExpectations(tc.controlleeKey))
 			assert.ElementsMatch(t, tc.deleteExpectationUIDsPostSync, expStore.GetDeleteExpectations(tc.controlleeKey))
 		})

--- a/operator/internal/expect/expectations_test.go
+++ b/operator/internal/expect/expectations_test.go
@@ -1,0 +1,231 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package expect
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const controlleeKey = "test-ns/test-resource"
+
+func TestExpectCreations(t *testing.T) {
+	testCases := []struct {
+		description                   string
+		existingUIDs                  []types.UID
+		newUIDs                       []types.UID
+		expectedCreateExpectationUIDs []types.UID
+	}{
+		{
+			description:                   "should create new expectation when none exists",
+			existingUIDs:                  nil,
+			newUIDs:                       []types.UID{"1", "2"},
+			expectedCreateExpectationUIDs: []types.UID{"1", "2"},
+		},
+		{
+			description:                   "should add unique new expectations when there are existing expectations",
+			existingUIDs:                  []types.UID{"1", "2"},
+			newUIDs:                       []types.UID{"1", "3", "4"},
+			expectedCreateExpectationUIDs: []types.UID{"1", "2", "3", "4"},
+		},
+	}
+
+	expStore := NewExpectationsStore()
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.existingUIDs != nil {
+				assert.NoError(t, initializeControlleeExpectations(expStore, controlleeKey, tc.existingUIDs, nil))
+			}
+			// test the method
+			wg := sync.WaitGroup{}
+			wg.Add(len(tc.newUIDs))
+			for _, uid := range tc.newUIDs {
+				go func() {
+					defer wg.Done()
+					err := expStore.ExpectCreations(logr.Discard(), controlleeKey, uid)
+					assert.NoError(t, err)
+				}()
+			}
+			wg.Wait()
+			// compare the expected with actual
+			assert.ElementsMatch(t, tc.expectedCreateExpectationUIDs, expStore.GetCreateExpectations(controlleeKey))
+		})
+	}
+}
+
+func TestObserveDeletions(t *testing.T) {
+	testCases := []struct {
+		description                   string
+		existingUIDs                  []types.UID
+		observedDeleteExpectationUIDs []types.UID
+		expectedDeleteExpectationUIDs []types.UID
+	}{
+		{
+			description:                   "should be no-op if UIDs to delete have already been removed",
+			existingUIDs:                  []types.UID{"1", "3", "5"},
+			observedDeleteExpectationUIDs: []types.UID{"8"},
+			expectedDeleteExpectationUIDs: []types.UID{"1", "3", "5"},
+		},
+		{
+			description:                   "should remove the observed deletions",
+			existingUIDs:                  []types.UID{"1", "2", "3", "5"},
+			observedDeleteExpectationUIDs: []types.UID{"2", "5"},
+			expectedDeleteExpectationUIDs: []types.UID{"1", "3"},
+		},
+	}
+
+	expStore := NewExpectationsStore()
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.existingUIDs != nil {
+				assert.NoError(t, initializeControlleeExpectations(expStore, controlleeKey, nil, tc.existingUIDs))
+			}
+			expStore.ObserveDeletions(logr.Discard(), controlleeKey, tc.observedDeleteExpectationUIDs...)
+			leftOverActualDeleteExpectations := expStore.GetDeleteExpectations(controlleeKey)
+			assert.ElementsMatch(t, tc.expectedDeleteExpectationUIDs, leftOverActualDeleteExpectations)
+		})
+	}
+}
+
+func TestExpectDeletions(t *testing.T) {
+	testCases := []struct {
+		description                   string
+		existingUIDs                  []types.UID
+		newUIDs                       []types.UID
+		expectedDeleteExpectationUIDs []types.UID
+	}{
+		{
+			description:                   "should create new expectation when none exists",
+			existingUIDs:                  nil,
+			newUIDs:                       []types.UID{"1", "2"},
+			expectedDeleteExpectationUIDs: []types.UID{"1", "2"},
+		},
+		{
+			description:                   "should add unique new expectations when there are existing expectations",
+			existingUIDs:                  []types.UID{"1", "2"},
+			newUIDs:                       []types.UID{"1", "3", "4"},
+			expectedDeleteExpectationUIDs: []types.UID{"1", "2", "3", "4"},
+		},
+	}
+
+	expStore := NewExpectationsStore()
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.existingUIDs != nil {
+				assert.NoError(t, initializeControlleeExpectations(expStore, controlleeKey, nil, tc.existingUIDs))
+			}
+			// test the method
+			wg := sync.WaitGroup{}
+			wg.Add(len(tc.newUIDs))
+			for _, uid := range tc.newUIDs {
+				go func() {
+					defer wg.Done()
+					err := expStore.ExpectDeletions(logr.Discard(), controlleeKey, uid)
+					assert.NoError(t, err)
+				}()
+			}
+			wg.Wait()
+			// compare the expected with actual
+			assert.ElementsMatch(t, tc.expectedDeleteExpectationUIDs, expStore.GetDeleteExpectations(controlleeKey))
+		})
+	}
+}
+
+func TestDeleteExpectations(t *testing.T) {
+	testCases := []struct {
+		description       string
+		expectationsExist bool
+	}{
+		{
+			description:       "should be a no-op when expectations do not exist",
+			expectationsExist: false,
+		},
+		{
+			description:       "should delete the existing expectations",
+			expectationsExist: true,
+		},
+	}
+
+	expStore := NewExpectationsStore()
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if tc.expectationsExist {
+				assert.NoError(t, initializeControlleeExpectations(expStore,
+					controlleeKey,
+					[]types.UID{"3"},
+					[]types.UID{"1", "2"}))
+			}
+			err := expStore.DeleteExpectations(logr.Discard(), controlleeKey)
+			assert.NoError(t, err)
+			_, exists, err := expStore.GetExpectations(controlleeKey)
+			assert.NoError(t, err)
+			assert.False(t, exists)
+		})
+	}
+}
+
+func TestSyncExpectations(t *testing.T) {
+	testCases := []struct {
+		description                   string
+		controlleeKey                 string
+		createExpectationUIDs         []types.UID
+		deleteExpectationsUIDs        []types.UID
+		existingUIDs                  []types.UID
+		createExpectationUIDsPostSync []types.UID
+		deleteExpectationUIDsPostSync []types.UID
+	}{
+		{
+			description:                   "should sync both create and delete expectations",
+			controlleeKey:                 controlleeKey,
+			createExpectationUIDs:         []types.UID{"1", "2"},
+			deleteExpectationsUIDs:        []types.UID{"3", "6"},
+			existingUIDs:                  []types.UID{"1", "3", "4", "7"},
+			createExpectationUIDsPostSync: []types.UID{"2"},
+			deleteExpectationUIDsPostSync: []types.UID{"3"},
+		},
+		{
+			description:                   "should be a no-op when expectations do not exist",
+			controlleeKey:                 "does-not-exist",
+			existingUIDs:                  []types.UID{"1", "2"},
+			createExpectationUIDsPostSync: []types.UID{},
+			deleteExpectationUIDsPostSync: []types.UID{},
+		},
+	}
+
+	expStore := NewExpectationsStore()
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.NoError(t, initializeControlleeExpectations(expStore, tc.controlleeKey, tc.createExpectationUIDs, tc.deleteExpectationsUIDs))
+			expStore.SyncExpectations(tc.controlleeKey, tc.existingUIDs...)
+			assert.ElementsMatch(t, tc.createExpectationUIDsPostSync, expStore.GetCreateExpectations(tc.controlleeKey))
+			assert.ElementsMatch(t, tc.deleteExpectationUIDsPostSync, expStore.GetDeleteExpectations(tc.controlleeKey))
+		})
+	}
+}
+
+func initializeControlleeExpectations(expStore *ExpectationsStore, controlleeKey string, uidsToAdd, uidsToDelete []types.UID) error {
+	return expStore.Add(&ControlleeExpectations{
+		key:          controlleeKey,
+		uidsToAdd:    sets.New(uidsToAdd...),
+		uidsToDelete: sets.New(uidsToDelete...),
+	})
+}

--- a/operator/internal/utils/kubernetes/pod.go
+++ b/operator/internal/utils/kubernetes/pod.go
@@ -35,7 +35,7 @@ const (
 	TerminatingPod corev1.PodConditionType = "TerminatingPod"
 	// PodStartedButNotReady is a custom corev1.PodConditionType that represents a Pod that has at least container whose
 	// status has started=true and ready=false.
-	// NOTE: We are currently NOT supporting any thresholds/initialDelays as defined in container probes. Supporf for that might come later.
+	// NOTE: We are currently NOT supporting any thresholds/initialDelays as defined in container probes. Support for that might come later.
 	PodStartedButNotReady corev1.PodConditionType = "PodStartedButNotReady"
 )
 
@@ -62,7 +62,7 @@ func CategorizePodsByConditionType(logger logr.Logger, pods []*corev1.Pod) map[c
 	return podCategories
 }
 
-// IsPodReady check the PodReady condition. If the condition is not set
+// IsPodReady checks the PodReady condition. If the condition is not set
 // it returns false else it returns the condition status value.
 func IsPodReady(pod *corev1.Pod) bool {
 	podReadyCond, ok := lo.Find(pod.Status.Conditions, func(cond corev1.PodCondition) bool {
@@ -96,7 +96,7 @@ func IsPodScheduled(pod *corev1.Pod) bool {
 	return scheduledCond.Status == corev1.ConditionTrue
 }
 
-// HasAnyContainerExitedErroneously check if any container has been terminated with a non-zero exit code in a Pod.
+// HasAnyContainerExitedErroneously checks if any container has been terminated with a non-zero exit code in a Pod.
 func HasAnyContainerExitedErroneously(logger logr.Logger, pod *corev1.Pod) bool {
 	podObjKey := client.ObjectKeyFromObject(pod)
 	// check init container statuses
@@ -126,8 +126,9 @@ func HasAnyStartedButNotReadyContainer(pod *corev1.Pod) bool {
 
 // GetContainerStatusIfTerminatedErroneously gets the first occurrence of corev1.ContainerStatus (across init, sidecar and main containers)
 // that has a non-zero LastTerminationState.Terminated.ExitCode. The reason to choose `containerStatus.LastTerminationState` instead of `containerStatus.State` is that
-// the `containerStatus.State` oscillates between waiting and terminating while the `containerStatus.LastTerminationState` captures the last termination state and
-// only changes when the container starts properly after multiple attempts, thus it is a more stable target state to observe.
+// the `containerStatus.State` oscillates between waiting and terminating in case of containers exiting with non-zero exit code, while the `containerStatus.LastTerminationState`
+// captures the last termination state and only changes when the container starts properly after multiple attempts, thus
+// it is a more stable target state to observe.
 func GetContainerStatusIfTerminatedErroneously(containerStatuses []corev1.ContainerStatus) *corev1.ContainerStatus {
 	containerStatus, ok := lo.Find(containerStatuses, func(containerStatus corev1.ContainerStatus) bool {
 		return containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode != 0

--- a/operator/internal/utils/kubernetes/pod.go
+++ b/operator/internal/utils/kubernetes/pod.go
@@ -1,0 +1,135 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package kubernetes
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// constants for extension PodConditionTypes.
+const (
+	// PodHasAtleastOneContainerWithNonZeroExitCode is a custom corev1.PodConditionType that represents a Pod which is NotReady and has at least one of its containers that
+	// have exited with an exit code != 0. This condition type will be used towards setting of MinAvailableBreached condition
+	// on the owner resource of a Pod.
+	PodHasAtleastOneContainerWithNonZeroExitCode corev1.PodConditionType = "PodHasAtleastOneContainerWithNonZeroExitCode"
+	// ScheduleGatedPod is a custom corev1.PodConditionType that represents a Pod which has one or more scheduling gates set.
+	ScheduleGatedPod corev1.PodConditionType = "ScheduleGatedPod"
+	// TerminatingPod is a custom corev1.PodConditionType that represents that this Pod has deletionTimestamp set on it.
+	TerminatingPod corev1.PodConditionType = "TerminatingPod"
+	// PodStartedButNotReady is a custom corev1.PodConditionType that represents a Pod that has at least container whose
+	// status has started=true and ready=false.
+	// NOTE: We are currently NOT supporting any thresholds/initialDelays as defined in container probes. Supporf for that might come later.
+	PodStartedButNotReady corev1.PodConditionType = "PodStartedButNotReady"
+)
+
+// CategorizePodsByConditionType groups pods by their pod condition. Three condition types a.k.a. categories are of interest:
+// 1. Ready pods, 2. ScheduleGated pods and 3. Pods that are NotReady and have at least one container with non-zero exit code.
+func CategorizePodsByConditionType(logger logr.Logger, pods []*corev1.Pod) map[corev1.PodConditionType][]*corev1.Pod {
+	podCategories := make(map[corev1.PodConditionType][]*corev1.Pod)
+	for _, pod := range pods {
+		if IsPodReady(pod) {
+			podCategories[corev1.PodReady] = append(podCategories[corev1.PodReady], pod)
+		} else if HasAnyContainerExitedErroneously(logger, pod) {
+			podCategories[PodHasAtleastOneContainerWithNonZeroExitCode] = append(podCategories[PodHasAtleastOneContainerWithNonZeroExitCode], pod)
+		} else if IsPodScheduleGated(pod) {
+			podCategories[ScheduleGatedPod] = append(podCategories[ScheduleGatedPod], pod)
+		} else if IsResourceTerminating(pod.ObjectMeta) {
+			podCategories[TerminatingPod] = append(podCategories[TerminatingPod], pod)
+		} else if HasAnyStartedButNotReadyContainer(pod) {
+			podCategories[PodStartedButNotReady] = append(podCategories[PodStartedButNotReady], pod)
+		}
+	}
+	return podCategories
+}
+
+// IsPodReady check the PodReady condition. If the condition is not set
+// it returns false else it returns the condition status value.
+func IsPodReady(pod *corev1.Pod) bool {
+	podReadyCond, ok := lo.Find(pod.Status.Conditions, func(cond corev1.PodCondition) bool {
+		return cond.Type == corev1.PodReady
+	})
+	if !ok {
+		return false
+	}
+	return podReadyCond.Status == corev1.ConditionTrue
+}
+
+// IsPodScheduleGated checks if there are scheduling gates added to the Pod.
+func IsPodScheduleGated(pod *corev1.Pod) bool {
+	scheduledCond, ok := lo.Find(pod.Status.Conditions, func(cond corev1.PodCondition) bool {
+		return cond.Type == corev1.PodScheduled
+	})
+	if !ok {
+		return false
+	}
+	return scheduledCond.Status == corev1.ConditionFalse && scheduledCond.Reason == corev1.PodReasonSchedulingGated
+}
+
+// HasAnyContainerExitedErroneously check if any container has been terminated with a non-zero exit code in a Pod.
+func HasAnyContainerExitedErroneously(logger logr.Logger, pod *corev1.Pod) bool {
+	podObjKey := client.ObjectKeyFromObject(pod)
+	// check init container statuses
+	erroneousInitContainerStatus := GetContainerStatusIfTerminatedErroneously(pod.Status.InitContainerStatuses)
+	if erroneousInitContainerStatus != nil {
+		logTerminatedErroneouslyPodContainerStatus(logger, podObjKey, erroneousInitContainerStatus)
+		return true
+	}
+	// check non-init container statuses
+	erroneousContainerStatus := GetContainerStatusIfTerminatedErroneously(pod.Status.ContainerStatuses)
+	if erroneousContainerStatus != nil {
+		logTerminatedErroneouslyPodContainerStatus(logger, podObjKey, erroneousContainerStatus)
+		return true
+	}
+	return false
+}
+
+// HasAnyStartedButNotReadyContainer checks if there is at least one container which has started but not ready.
+func HasAnyStartedButNotReadyContainer(pod *corev1.Pod) bool {
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.Started != nil && *containerStatus.Started && !containerStatus.Ready {
+			return true
+		}
+	}
+	return false
+}
+
+// GetContainerStatusIfTerminatedErroneously gets the first occurrence of corev1.ContainerStatus (across init, sidecar and main containers)
+// that has a non-zero LastTerminationState.Terminated.ExitCode. The reason to choose `containerStatus.LastTerminationState` instead of `containerStatus.State` is that
+// the `containerStatus.State` oscillates between waiting and terminating while the `containerStatus.LastTerminationState` captures the last termination state and
+// only changes when the container starts properly after multiple attempts, thus it is a more stable target state to observe.
+func GetContainerStatusIfTerminatedErroneously(containerStatuses []corev1.ContainerStatus) *corev1.ContainerStatus {
+	containerStatus, ok := lo.Find(containerStatuses, func(containerStatus corev1.ContainerStatus) bool {
+		return containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode != 0
+	})
+	if !ok {
+		return nil
+	}
+	return &containerStatus
+}
+
+func logTerminatedErroneouslyPodContainerStatus(logger logr.Logger, podObjKey client.ObjectKey, containerStatus *corev1.ContainerStatus) {
+	if containerStatus != nil {
+		logger.Info("container exited with a non-zero exit code",
+			"pod", podObjKey,
+			"container", containerStatus.Name,
+			"exitCode", containerStatus.State.Terminated.ExitCode,
+			"exitReason", containerStatus.State.Terminated.Reason)
+	}
+}

--- a/operator/internal/utils/miscellaneous.go
+++ b/operator/internal/utils/miscellaneous.go
@@ -22,3 +22,8 @@ import "strings"
 func IsEmptyStringType[T ~string](val T) bool {
 	return len(strings.TrimSpace(string(val))) == 0
 }
+
+// OnlyOneIsNil returns true if only one of the Objects is nil else it will return false.
+func OnlyOneIsNil[T any](objA, objB *T) bool {
+	return (objA == nil) != (objB == nil)
+}


### PR DESCRIPTION
Resolves #122 

This PR introduces the following changes:
- Removes `PodClique.Status.UpdatedReplicas` - this is not required as during rolling recreate the  PodGangs and therefore the PodCliques will be recreated and not updated.
- Corrected JSON tag of `PodGangSet.Status.LastOperation.LastUpdateTime`
- Created `operator/internal/components/events/constants.go` to host all the constants used when emitting events.
- Added `ExpectationsStore` which has a different implementation as compared to what is present in upstream k8s github. They used expectations as a barrier and that has open issues which have not been resolved till date.
- Pod component has been refactored to now use expectations.
- Error codes have been corrected across `Pod` and `PodCliqueScalingGroup` and `PodClique` components. This will be harmonized across all components in a later PR.
- Added support to emit events for create/delete of `Pod`, `PodClique`, `PodCliqueScalingGroup` and `PodGang` resources.
- Corrected the issue where the `PodGang` was unnecessarily getting updated. Only the order of `Pod` references were changing. This was causing a lot of events to be queued into the `PodClique` reconciler.
- An attempt is made to reduce the number of events in general across reconcilers in this PR. This is an ongoing effort and cannot be marked as done in this PR.
- PodGangSet reconciler now listens for `MinAvailableBreached` condition changes on `PodCliqueScalingGroup` resources.
- PodClique reconciler now adds support to compute `MinAvailableBreached` condition based on the following conditions:
  - Checks if any of the main containers have `started=true` and `ready=false`. In this PR we do not support any initial delays that are configured for a readiness probe for a container. This might be introduced later.
  - Checks if any of the containers (init, sidecar or main) have a non-zero exitCode
If any of the above conditions are met then it will consider these pods when computing the `MinAvailableBreached`.
- Introduces new `PodClique.Status.ScheduledReplicas` and `PodCliqueScalingGroup.Status.ScheduledReplicas`
- Introduces new condition `PodCliqueScheduled` in `PodClique` resources.
- Refactored the code to determine `MinAvailableBreached` condition in both PCLQ and PCSG reconcilers.
- Fixed a bug: After introducing of `minAvailable` replicas for PCSG, the reconcile status flow in PCSG reconciler was still comparing PCSG replicas against the defaultMinAvailable (=1) replicas. This was a miss which has now been fixed.


