### PR TITLE
feat: set default HeadlessServiceConfig to publish not ready addresses

### DIFF
--- a/operator/internal/webhook/admission/pgs/defaulting/podgangset.go
+++ b/operator/internal/webhook/admission/pgs/defaulting/podgangset.go
@@ -53,6 +53,17 @@ func defaultPodGangSetTemplateSpec(spec *grovecorev1alpha1.PodGangSetTemplateSpe
 	if spec.TerminationDelay == nil {
 		spec.TerminationDelay = &metav1.Duration{Duration: defaultTerminationDelay}
 	}
+
+	spec.HeadlessServiceConfig = defaultHeadlessServiceConfig(spec.HeadlessServiceConfig)
+}
+
+func defaultHeadlessServiceConfig(headlessServiceConfig *grovecorev1alpha1.HeadlessServiceConfig) *grovecorev1alpha1.HeadlessServiceConfig {
+	if headlessServiceConfig == nil {
+		headlessServiceConfig = &grovecorev1alpha1.HeadlessServiceConfig{
+			PublishNotReadyAddresses: true,
+		}
+	}
+	return headlessServiceConfig
 }
 
 func defaultPodCliqueTemplateSpecs(cliqueSpecs []*grovecorev1alpha1.PodCliqueTemplateSpec) []*grovecorev1alpha1.PodCliqueTemplateSpec {

--- a/operator/internal/webhook/admission/pgs/defaulting/podgangset_test.go
+++ b/operator/internal/webhook/admission/pgs/defaulting/podgangset_test.go
@@ -75,9 +75,6 @@ func TestDefaultPodGangSet(t *testing.T) {
 						},
 					},
 				}},
-				HeadlessServiceConfig: &grovecorev1alpha1.HeadlessServiceConfig{
-					PublishNotReadyAddresses: true,
-				},
 			},
 		},
 	}


### PR DESCRIPTION
https://github.com/NVIDIA/grove/issues/134
This pull request introduces a defaulting mechanism for the `HeadlessServiceConfig` field within the `PodGangSetTemplateSpec` struct. The main change ensures that if `HeadlessServiceConfig` is not set, it is automatically initialized with sensible defaults. Additionally, the related test has been updated to reflect this new defaulting behavior.

Defaulting logic improvements:

* Added a `defaultHeadlessServiceConfig` function to initialize `HeadlessServiceConfig` with `PublishNotReadyAddresses: true` if it is not already set, and integrated this logic into the `defaultPodGangSetTemplateSpec` function (`operator/internal/webhook/admission/pgs/defaulting/podgangset.go`).

Test updates:

* Updated the `TestDefaultPodGangSet` test case to remove the explicit setting of `HeadlessServiceConfig`, as it is now automatically defaulted (`operator/internal/webhook/admission/pgs/defaulting/podgangset_test.go`).