### PR TITLE
Adding unit testing to utils 

### DIFF
--- a/operator/internal/controller/utils/managedresource_test.go
+++ b/operator/internal/controller/utils/managedresource_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"

--- a/operator/internal/controller/utils/managedresource_test.go
+++ b/operator/internal/controller/utils/managedresource_test.go
@@ -1,0 +1,315 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package utils
+
+import (
+	"testing"
+
+	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Test helper functions
+func newOwnerReference(kind, name string, isController bool) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: "grove.io/v1alpha1",
+		Kind:       kind,
+		Name:       name,
+		UID:        uuid.NewUUID(),
+		Controller: ptr.To(isController),
+	}
+}
+
+func newLabelsWithManagedBy(managedByValue string) map[string]string {
+	return map[string]string{
+		grovecorev1alpha1.LabelManagedByKey: managedByValue,
+	}
+}
+
+func newLabelsWithManagedByAndExtras(managedByValue string, extraLabels map[string]string) map[string]string {
+	labels := newLabelsWithManagedBy(managedByValue)
+	for k, v := range extraLabels {
+		labels[k] = v
+	}
+	return labels
+}
+
+func newTestPodClique(name, namespace string, labels map[string]string, ownerRefs ...metav1.OwnerReference) *grovecorev1alpha1.PodClique {
+	return &grovecorev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			OwnerReferences: ownerRefs,
+		},
+	}
+}
+
+func TestHasExpectedOwner(t *testing.T) {
+	testCases := []struct {
+		description       string
+		expectedOwnerKind string
+		ownerRefs         []metav1.OwnerReference
+		expected          bool
+	}{
+		{
+			description:       "should return true when single owner matches expected kind",
+			expectedOwnerKind: "PodGangSet",
+			ownerRefs:         []metav1.OwnerReference{newOwnerReference("PodGangSet", "test-pgs", true)},
+			expected:          true,
+		},
+		{
+			description:       "should return false when single owner does not match expected kind",
+			expectedOwnerKind: "PodGangSet",
+			ownerRefs:         []metav1.OwnerReference{newOwnerReference("PodCliqueScalingGroup", "test-pcsg", true)},
+			expected:          false,
+		},
+		{
+			description:       "should return false when no owner references exist",
+			expectedOwnerKind: "PodGangSet",
+			ownerRefs:         []metav1.OwnerReference{},
+			expected:          false,
+		},
+		{
+			description:       "should return false when owner references is nil",
+			expectedOwnerKind: "PodGangSet",
+			ownerRefs:         nil,
+			expected:          false,
+		},
+		{
+			description:       "should return false when multiple owner references exist",
+			expectedOwnerKind: "PodGangSet",
+			ownerRefs: []metav1.OwnerReference{
+				newOwnerReference("PodGangSet", "test-pgs", true),
+				newOwnerReference("PodCliqueScalingGroup", "test-pcsg", false),
+			},
+			expected: false,
+		},
+		{
+			description:       "should return true when single owner matches with different case",
+			expectedOwnerKind: "PodGangSet",
+			ownerRefs:         []metav1.OwnerReference{newOwnerReference("PodGangSet", "test-pgs", false)},
+			expected:          true,
+		},
+		{
+			description:       "should return false when kind is empty string",
+			expectedOwnerKind: "",
+			ownerRefs:         []metav1.OwnerReference{newOwnerReference("PodGangSet", "test-pgs", true)},
+			expected:          false,
+		},
+		{
+			description:       "should return false when owner reference kind is empty",
+			expectedOwnerKind: "PodGangSet",
+			ownerRefs:         []metav1.OwnerReference{newOwnerReference("", "test-pgs", true)},
+			expected:          false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := HasExpectedOwner(tc.expectedOwnerKind, tc.ownerRefs)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestIsManagedByGrove(t *testing.T) {
+	testCases := []struct {
+		description string
+		labels      map[string]string
+		expected    bool
+	}{
+		{
+			description: "should return true when managed-by label has correct value",
+			labels:      newLabelsWithManagedBy(grovecorev1alpha1.LabelManagedByValue),
+			expected:    true,
+		},
+		{
+			description: "should return false when managed-by label has incorrect value",
+			labels:      newLabelsWithManagedBy("other-operator"),
+			expected:    false,
+		},
+		{
+			description: "should return false when managed-by label is missing",
+			labels: map[string]string{
+				"app":     "test-app",
+				"version": "v1.0",
+			},
+			expected: false,
+		},
+		{
+			description: "should return false when labels map is empty",
+			labels:      map[string]string{},
+			expected:    false,
+		},
+		{
+			description: "should return false when labels map is nil",
+			labels:      nil,
+			expected:    false,
+		},
+		{
+			description: "should return true when managed-by label is correct with other labels",
+			labels: newLabelsWithManagedByAndExtras(grovecorev1alpha1.LabelManagedByValue, map[string]string{
+				"app":         "test-app",
+				"version":     "v1.0",
+				"environment": "test",
+			}),
+			expected: true,
+		},
+		{
+			description: "should return false when managed-by label has empty value",
+			labels:      newLabelsWithManagedBy(""),
+			expected:    false,
+		},
+		{
+			description: "should return false when managed-by label has whitespace value",
+			labels:      newLabelsWithManagedBy("  "),
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := IsManagedByGrove(tc.labels)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestIsManagedPodClique(t *testing.T) {
+	testCases := []struct {
+		description        string
+		obj                client.Object
+		expectedOwnerKinds []string
+		expected           bool
+	}{
+		{
+			description: "should return true when PodClique is managed by Grove with correct owner",
+			obj: newTestPodClique(
+				"managed-pclq",
+				"test-ns",
+				newLabelsWithManagedBy(grovecorev1alpha1.LabelManagedByValue),
+				newOwnerReference("PodGangSet", "test-pgs", true),
+			),
+			expectedOwnerKinds: []string{"PodGangSet"},
+			expected:           true,
+		},
+		{
+			description: "should return false when PodClique is not managed by Grove",
+			obj: newTestPodClique(
+				"unmanaged-pclq",
+				"test-ns",
+				newLabelsWithManagedBy("other-operator"),
+				newOwnerReference("PodGangSet", "test-pgs", true),
+			),
+			expectedOwnerKinds: []string{"PodGangSet"},
+			expected:           false,
+		},
+		{
+			description: "should return false when PodClique has wrong owner kind",
+			obj: newTestPodClique(
+				"wrong-owner-pclq",
+				"test-ns",
+				newLabelsWithManagedBy(grovecorev1alpha1.LabelManagedByValue),
+				newOwnerReference("WrongKind", "test-wrong", true),
+			),
+			expectedOwnerKinds: []string{"PodGangSet"},
+			expected:           false,
+		},
+		{
+			description: "should return true when PodClique matches one of multiple expected owner kinds",
+			obj: newTestPodClique(
+				"pcsg-owned-pclq",
+				"test-ns",
+				newLabelsWithManagedBy(grovecorev1alpha1.LabelManagedByValue),
+				newOwnerReference("PodCliqueScalingGroup", "test-pcsg", true),
+			),
+			expectedOwnerKinds: []string{"PodGangSet", "PodCliqueScalingGroup"},
+			expected:           true,
+		},
+		{
+			description: "should return false when object is not a PodClique",
+			obj: &grovecorev1alpha1.PodGangSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pgs",
+					Namespace: "different-ns",
+					Labels:    newLabelsWithManagedBy(grovecorev1alpha1.LabelManagedByValue),
+					OwnerReferences: []metav1.OwnerReference{
+						newOwnerReference("PodGangSet", "test-pgs", true),
+					},
+				},
+			},
+			expectedOwnerKinds: []string{"PodGangSet"},
+			expected:           false,
+		},
+		{
+			description: "should return false when PodClique has no labels",
+			obj: newTestPodClique(
+				"no-labels-pclq",
+				"test-ns",
+				nil,
+				newOwnerReference("PodGangSet", "test-pgs", true),
+			),
+			expectedOwnerKinds: []string{"PodGangSet"},
+			expected:           false,
+		},
+		{
+			description: "should return false when PodClique has no owner references",
+			obj: newTestPodClique(
+				"no-owners-pclq",
+				"another-ns",
+				newLabelsWithManagedBy(grovecorev1alpha1.LabelManagedByValue),
+			),
+			expectedOwnerKinds: []string{"PodGangSet"},
+			expected:           false,
+		},
+		{
+			description: "should return false when no expected owner kinds provided",
+			obj: newTestPodClique(
+				"no-expected-pclq",
+				"test-ns",
+				newLabelsWithManagedBy(grovecorev1alpha1.LabelManagedByValue),
+				newOwnerReference("PodGangSet", "test-pgs", true),
+			),
+			expectedOwnerKinds: []string{},
+			expected:           false,
+		},
+		{
+			description: "should return false when PodClique has multiple owners",
+			obj: newTestPodClique(
+				"multi-owners-pclq",
+				"test-ns",
+				newLabelsWithManagedBy(grovecorev1alpha1.LabelManagedByValue),
+				newOwnerReference("PodGangSet", "test-pgs", true),
+				newOwnerReference("PodCliqueScalingGroup", "test-pcsg", false),
+			),
+			expectedOwnerKinds: []string{"PodGangSet"},
+			expected:           false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := IsManagedPodClique(tc.obj, tc.expectedOwnerKinds...)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/operator/internal/controller/utils/managedresource_test.go
+++ b/operator/internal/controller/utils/managedresource_test.go
@@ -79,24 +79,6 @@ func TestHasExpectedOwner(t *testing.T) {
 			},
 			expected: false,
 		},
-		{
-			description:       "should return true when single owner matches with different case",
-			expectedOwnerKind: "PodGangSet",
-			ownerRefs:         []metav1.OwnerReference{newOwnerReference("PodGangSet", "test-pgs", false)},
-			expected:          true,
-		},
-		{
-			description:       "should return false when kind is empty string",
-			expectedOwnerKind: "",
-			ownerRefs:         []metav1.OwnerReference{newOwnerReference("PodGangSet", "test-pgs", true)},
-			expected:          false,
-		},
-		{
-			description:       "should return false when owner reference kind is empty",
-			expectedOwnerKind: "PodGangSet",
-			ownerRefs:         []metav1.OwnerReference{newOwnerReference("", "test-pgs", true)},
-			expected:          false,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -136,38 +118,9 @@ func TestIsManagedByGrove(t *testing.T) {
 			expected: false,
 		},
 		{
-			description: "should return false when labels map is empty",
-			labels:      map[string]string{},
-			expected:    false,
-		},
-		{
 			description: "should return false when labels map is nil",
 			labels:      nil,
 			expected:    false,
-		},
-		{
-			description: "should return true when managed-by label is correct with other labels",
-			labels: map[string]string{
-				grovecorev1alpha1.LabelManagedByKey: grovecorev1alpha1.LabelManagedByValue,
-				"app":                               "test-app",
-				"version":                           "v1.0",
-				"environment":                       "test",
-			},
-			expected: true,
-		},
-		{
-			description: "should return false when managed-by label has empty value",
-			labels: map[string]string{
-				grovecorev1alpha1.LabelManagedByKey: "",
-			},
-			expected: false,
-		},
-		{
-			description: "should return false when managed-by label has whitespace value",
-			labels: map[string]string{
-				grovecorev1alpha1.LabelManagedByKey: "  ",
-			},
-			expected: false,
 		},
 	}
 
@@ -238,23 +191,6 @@ func TestIsManagedPodClique(t *testing.T) {
 			expected:           false,
 		},
 		{
-			description: "should return true when PodClique matches one of multiple expected owner kinds",
-			obj: &grovecorev1alpha1.PodClique{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pcsg-owned-pclq",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						grovecorev1alpha1.LabelManagedByKey: grovecorev1alpha1.LabelManagedByValue,
-					},
-					OwnerReferences: []metav1.OwnerReference{
-						newOwnerReference("PodCliqueScalingGroup", "test-pcsg", true),
-					},
-				},
-			},
-			expectedOwnerKinds: []string{"PodGangSet", "PodCliqueScalingGroup"},
-			expected:           true,
-		},
-		{
 			description: "should return false when object is not a PodClique",
 			obj: &grovecorev1alpha1.PodGangSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -280,55 +216,6 @@ func TestIsManagedPodClique(t *testing.T) {
 					Labels:    nil,
 					OwnerReferences: []metav1.OwnerReference{
 						newOwnerReference("PodGangSet", "test-pgs", true),
-					},
-				},
-			},
-			expectedOwnerKinds: []string{"PodGangSet"},
-			expected:           false,
-		},
-		{
-			description: "should return false when PodClique has no owner references",
-			obj: &grovecorev1alpha1.PodClique{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-owners-pclq",
-					Namespace: "another-ns",
-					Labels: map[string]string{
-						grovecorev1alpha1.LabelManagedByKey: grovecorev1alpha1.LabelManagedByValue,
-					},
-				},
-			},
-			expectedOwnerKinds: []string{"PodGangSet"},
-			expected:           false,
-		},
-		{
-			description: "should return false when no expected owner kinds provided",
-			obj: &grovecorev1alpha1.PodClique{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "no-expected-pclq",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						grovecorev1alpha1.LabelManagedByKey: grovecorev1alpha1.LabelManagedByValue,
-					},
-					OwnerReferences: []metav1.OwnerReference{
-						newOwnerReference("PodGangSet", "test-pgs", true),
-					},
-				},
-			},
-			expectedOwnerKinds: []string{},
-			expected:           false,
-		},
-		{
-			description: "should return false when PodClique has multiple owners",
-			obj: &grovecorev1alpha1.PodClique{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "multi-owners-pclq",
-					Namespace: "test-ns",
-					Labels: map[string]string{
-						grovecorev1alpha1.LabelManagedByKey: grovecorev1alpha1.LabelManagedByValue,
-					},
-					OwnerReferences: []metav1.OwnerReference{
-						newOwnerReference("PodGangSet", "test-pgs", true),
-						newOwnerReference("PodCliqueScalingGroup", "test-pcsg", false),
 					},
 				},
 			},

--- a/operator/internal/controller/utils/reconciler_test.go
+++ b/operator/internal/controller/utils/reconciler_test.go
@@ -20,19 +20,10 @@ import (
 	"errors"
 	"testing"
 
-	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
 
 	"github.com/stretchr/testify/assert"
 )
-
-// Test helper functions
-func newGroveError(code grovecorev1alpha1.ErrorCode, message string) error {
-	return &groveerr.GroveError{
-		Code:    code,
-		Message: message,
-	}
-}
 
 func TestShouldRequeueAfter(t *testing.T) {
 	testCases := []struct {
@@ -42,18 +33,27 @@ func TestShouldRequeueAfter(t *testing.T) {
 	}{
 		{
 			description: "should return true for GroveError with RequeueAfter code",
-			err:         newGroveError(groveerr.ErrCodeRequeueAfter, "test requeue after error"),
-			expected:    true,
+			err: &groveerr.GroveError{
+				Code:    groveerr.ErrCodeRequeueAfter,
+				Message: "test requeue after error",
+			},
+			expected: true,
 		},
 		{
 			description: "should return false for GroveError with ContinueReconcileAndRequeue code",
-			err:         newGroveError(groveerr.ErrCodeContinueReconcileAndRequeue, "test continue and requeue error"),
-			expected:    false,
+			err: &groveerr.GroveError{
+				Code:    groveerr.ErrCodeContinueReconcileAndRequeue,
+				Message: "test continue and requeue error",
+			},
+			expected: false,
 		},
 		{
 			description: "should return false for GroveError with other code",
-			err:         newGroveError("ERR_OTHER_CODE", "test other error"),
-			expected:    false,
+			err: &groveerr.GroveError{
+				Code:    "ERR_OTHER_CODE",
+				Message: "test other error",
+			},
+			expected: false,
 		},
 		{
 			description: "should return false for non-GroveError",
@@ -88,18 +88,27 @@ func TestShouldContinueReconcileAndRequeue(t *testing.T) {
 	}{
 		{
 			description: "should return true for GroveError with ContinueReconcileAndRequeue code",
-			err:         newGroveError(groveerr.ErrCodeContinueReconcileAndRequeue, "test continue and requeue error"),
-			expected:    true,
+			err: &groveerr.GroveError{
+				Code:    groveerr.ErrCodeContinueReconcileAndRequeue,
+				Message: "test continue and requeue error",
+			},
+			expected: true,
 		},
 		{
 			description: "should return false for GroveError with RequeueAfter code",
-			err:         newGroveError(groveerr.ErrCodeRequeueAfter, "test requeue after error"),
-			expected:    false,
+			err: &groveerr.GroveError{
+				Code:    groveerr.ErrCodeRequeueAfter,
+				Message: "test requeue after error",
+			},
+			expected: false,
 		},
 		{
 			description: "should return false for GroveError with other code",
-			err:         newGroveError("ERR_OTHER_CODE", "test other error"),
-			expected:    false,
+			err: &groveerr.GroveError{
+				Code:    "ERR_OTHER_CODE",
+				Message: "test other error",
+			},
+			expected: false,
 		},
 		{
 			description: "should return false for non-GroveError",
@@ -118,8 +127,11 @@ func TestShouldContinueReconcileAndRequeue(t *testing.T) {
 		},
 		{
 			description: "should return false for GroveError with unknown code",
-			err:         newGroveError("unknown-code", "test unknown code error"),
-			expected:    false,
+			err: &groveerr.GroveError{
+				Code:    "unknown-code",
+				Message: "test unknown code error",
+			},
+			expected: false,
 		},
 	}
 

--- a/operator/internal/controller/utils/reconciler_test.go
+++ b/operator/internal/controller/utils/reconciler_test.go
@@ -1,0 +1,131 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test helper functions
+func newGroveError(code grovecorev1alpha1.ErrorCode, message string) error {
+	return &groveerr.GroveError{
+		Code:    code,
+		Message: message,
+	}
+}
+
+func TestShouldRequeueAfter(t *testing.T) {
+	testCases := []struct {
+		description string
+		err         error
+		expected    bool
+	}{
+		{
+			description: "should return true for GroveError with RequeueAfter code",
+			err:         newGroveError(groveerr.ErrCodeRequeueAfter, "test requeue after error"),
+			expected:    true,
+		},
+		{
+			description: "should return false for GroveError with ContinueReconcileAndRequeue code",
+			err:         newGroveError(groveerr.ErrCodeContinueReconcileAndRequeue, "test continue and requeue error"),
+			expected:    false,
+		},
+		{
+			description: "should return false for GroveError with other code",
+			err:         newGroveError("ERR_OTHER_CODE", "test other error"),
+			expected:    false,
+		},
+		{
+			description: "should return false for non-GroveError",
+			err:         errors.New("standard error"),
+			expected:    false,
+		},
+		{
+			description: "should return false for nil error",
+			err:         nil,
+			expected:    false,
+		},
+		{
+			description: "should return false for wrapped standard error",
+			err:         errors.New("wrapped: standard error"),
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := ShouldRequeueAfter(tc.err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestShouldContinueReconcileAndRequeue(t *testing.T) {
+	testCases := []struct {
+		description string
+		err         error
+		expected    bool
+	}{
+		{
+			description: "should return true for GroveError with ContinueReconcileAndRequeue code",
+			err:         newGroveError(groveerr.ErrCodeContinueReconcileAndRequeue, "test continue and requeue error"),
+			expected:    true,
+		},
+		{
+			description: "should return false for GroveError with RequeueAfter code",
+			err:         newGroveError(groveerr.ErrCodeRequeueAfter, "test requeue after error"),
+			expected:    false,
+		},
+		{
+			description: "should return false for GroveError with other code",
+			err:         newGroveError("ERR_OTHER_CODE", "test other error"),
+			expected:    false,
+		},
+		{
+			description: "should return false for non-GroveError",
+			err:         errors.New("standard error"),
+			expected:    false,
+		},
+		{
+			description: "should return false for nil error",
+			err:         nil,
+			expected:    false,
+		},
+		{
+			description: "should return false for wrapped standard error",
+			err:         errors.New("wrapped: standard error"),
+			expected:    false,
+		},
+		{
+			description: "should return false for GroveError with unknown code",
+			err:         newGroveError("unknown-code", "test unknown code error"),
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := ShouldContinueReconcileAndRequeue(tc.err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/operator/internal/controller/utils/reconciler_test.go
+++ b/operator/internal/controller/utils/reconciler_test.go
@@ -22,6 +22,7 @@ import (
 
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/operator/internal/utils/kubernetes/conditions_test.go
+++ b/operator/internal/utils/kubernetes/conditions_test.go
@@ -25,14 +25,6 @@ import (
 )
 
 // Test helper functions
-func newCondition(condType string, status metav1.ConditionStatus, reason, message string) metav1.Condition {
-	return metav1.Condition{
-		Type:    condType,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
-	}
-}
 
 func newSimpleCondition(condType string, status metav1.ConditionStatus) metav1.Condition {
 	return metav1.Condition{

--- a/operator/internal/utils/kubernetes/conditions_test.go
+++ b/operator/internal/utils/kubernetes/conditions_test.go
@@ -21,7 +21,50 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
+
+// Test helper functions
+func newCondition(condType string, status metav1.ConditionStatus, reason, message string) metav1.Condition {
+	return metav1.Condition{
+		Type:    condType,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
+func newSimpleCondition(condType string, status metav1.ConditionStatus) metav1.Condition {
+	return metav1.Condition{
+		Type:   condType,
+		Status: status,
+	}
+}
+
+// Common condition builders
+func readyTrueCondition() metav1.Condition {
+	return newSimpleCondition("Ready", metav1.ConditionTrue)
+}
+
+func readyFalseCondition() metav1.Condition {
+	return newSimpleCondition("Ready", metav1.ConditionFalse)
+}
+
+func readyUnknownCondition() metav1.Condition {
+	return newSimpleCondition("Ready", metav1.ConditionUnknown)
+}
+
+func availableTrueCondition() metav1.Condition {
+	return newSimpleCondition("Available", metav1.ConditionTrue)
+}
+
+func availableFalseCondition() metav1.Condition {
+	return newSimpleCondition("Available", metav1.ConditionFalse)
+}
+
+func availableUnknownCondition() metav1.Condition {
+	return newSimpleCondition("Available", metav1.ConditionUnknown)
+}
 
 func TestHasConditionsChanged(t *testing.T) {
 	testCases := []struct {
@@ -79,6 +122,181 @@ func TestHasConditionsChanged(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, testCase.expectedResult, HasConditionChanged(testCase.existingConditions, testCase.newCondition))
+		})
+	}
+}
+
+func TestIsConditionTrue(t *testing.T) {
+	testCases := []struct {
+		description        string
+		existingConditions []metav1.Condition
+		conditionType      string
+		expectedResult     bool
+	}{
+		{
+			description:        "should return true when condition exists and is True",
+			existingConditions: []metav1.Condition{readyTrueCondition(), availableFalseCondition()},
+			conditionType:      "Ready",
+			expectedResult:     true,
+		},
+		{
+			description:        "should return false when condition exists and is False",
+			existingConditions: []metav1.Condition{readyFalseCondition(), availableTrueCondition()},
+			conditionType:      "Ready",
+			expectedResult:     false,
+		},
+		{
+			description:        "should return false when condition exists and is Unknown",
+			existingConditions: []metav1.Condition{readyUnknownCondition(), availableTrueCondition()},
+			conditionType:      "Ready",
+			expectedResult:     false,
+		},
+		{
+			description:        "should return false when condition does not exist",
+			existingConditions: []metav1.Condition{availableTrueCondition()},
+			conditionType:      "Ready",
+			expectedResult:     false,
+		},
+		{
+			description:        "should return false when conditions list is empty",
+			existingConditions: []metav1.Condition{},
+			conditionType:      "Ready",
+			expectedResult:     false,
+		},
+		{
+			description:        "should return false when conditions list is nil",
+			existingConditions: nil,
+			conditionType:      "Ready",
+			expectedResult:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := IsConditionTrue(tc.existingConditions, tc.conditionType)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestIsConditionUnknown(t *testing.T) {
+	testCases := []struct {
+		description        string
+		existingConditions []metav1.Condition
+		conditionType      string
+		expectedResult     bool
+	}{
+		{
+			description:        "should return true when condition exists and is Unknown",
+			existingConditions: []metav1.Condition{readyUnknownCondition(), availableTrueCondition()},
+			conditionType:      "Ready",
+			expectedResult:     true,
+		},
+		{
+			description:        "should return false when condition exists and is True",
+			existingConditions: []metav1.Condition{readyTrueCondition(), availableUnknownCondition()},
+			conditionType:      "Ready",
+			expectedResult:     false,
+		},
+		{
+			description:        "should return false when condition exists and is False",
+			existingConditions: []metav1.Condition{readyFalseCondition(), availableUnknownCondition()},
+			conditionType:      "Ready",
+			expectedResult:     false,
+		},
+		{
+			description:        "should return false when condition does not exist",
+			existingConditions: []metav1.Condition{availableUnknownCondition()},
+			conditionType:      "Ready",
+			expectedResult:     false,
+		},
+		{
+			description:        "should return false when conditions list is empty",
+			existingConditions: []metav1.Condition{},
+			conditionType:      "Ready",
+			expectedResult:     false,
+		},
+		{
+			description:        "should return false when conditions list is nil",
+			existingConditions: nil,
+			conditionType:      "Ready",
+			expectedResult:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := IsConditionUnknown(tc.existingConditions, tc.conditionType)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestGetConditionStatus(t *testing.T) {
+	testCases := []struct {
+		description        string
+		existingConditions []metav1.Condition
+		conditionType      string
+		expectedStatus     *metav1.ConditionStatus
+	}{
+		{
+			description:        "should return True status when condition exists and is True",
+			existingConditions: []metav1.Condition{readyTrueCondition(), availableFalseCondition()},
+			conditionType:      "Ready",
+			expectedStatus:     ptr.To(metav1.ConditionTrue),
+		},
+		{
+			description:        "should return False status when condition exists and is False",
+			existingConditions: []metav1.Condition{readyFalseCondition(), availableTrueCondition()},
+			conditionType:      "Ready",
+			expectedStatus:     ptr.To(metav1.ConditionFalse),
+		},
+		{
+			description:        "should return Unknown status when condition exists and is Unknown",
+			existingConditions: []metav1.Condition{readyUnknownCondition(), availableTrueCondition()},
+			conditionType:      "Ready",
+			expectedStatus:     ptr.To(metav1.ConditionUnknown),
+		},
+		{
+			description:        "should return nil when condition does not exist",
+			existingConditions: []metav1.Condition{availableTrueCondition()},
+			conditionType:      "Ready",
+			expectedStatus:     nil,
+		},
+		{
+			description:        "should return nil when conditions list is empty",
+			existingConditions: []metav1.Condition{},
+			conditionType:      "Ready",
+			expectedStatus:     nil,
+		},
+		{
+			description:        "should return nil when conditions list is nil",
+			existingConditions: nil,
+			conditionType:      "Ready",
+			expectedStatus:     nil,
+		},
+		{
+			description: "should return correct status when multiple conditions with same type exist (first match)",
+			existingConditions: []metav1.Condition{
+				readyTrueCondition(),
+				readyFalseCondition(), // This one should be ignored
+				availableUnknownCondition(),
+			},
+			conditionType:  "Ready",
+			expectedStatus: ptr.To(metav1.ConditionTrue),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := GetConditionStatus(tc.existingConditions, tc.conditionType)
+
+			if tc.expectedStatus == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Equal(t, *tc.expectedStatus, *result)
+			}
 		})
 	}
 }

--- a/operator/internal/utils/kubernetes/labels_test.go
+++ b/operator/internal/utils/kubernetes/labels_test.go
@@ -44,13 +44,6 @@ func newTestObjectMetaWithLabels(labels map[string]string) metav1.ObjectMeta {
 	}
 }
 
-func newTestObjectMetaEmpty() metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:      "test-resource",
-		Namespace: "test-ns",
-	}
-}
-
 func newTestObjectMetaNilLabels() metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:      "test-resource",

--- a/operator/internal/utils/kubernetes/labels_test.go
+++ b/operator/internal/utils/kubernetes/labels_test.go
@@ -53,14 +53,10 @@ func newTestObjectMetaNilLabels() metav1.ObjectMeta {
 	}
 }
 
-func newLabelsWithReplicaIndex(index string) map[string]string {
-	return map[string]string{
+func newLabelsWithReplicaIndexAndExtras(index string, extraLabels map[string]string) map[string]string {
+	labels := map[string]string{
 		grovev1alpha1.LabelPodGangSetReplicaIndex: index,
 	}
-}
-
-func newLabelsWithReplicaIndexAndExtras(index string, extraLabels map[string]string) map[string]string {
-	labels := newLabelsWithReplicaIndex(index)
 	for k, v := range extraLabels {
 		labels[k] = v
 	}
@@ -74,24 +70,6 @@ func TestGetPodGangSetReplicaIndex(t *testing.T) {
 		expectedIndex int
 		expectedError error
 	}{
-		{
-			description:   "valid replica index 0",
-			objMeta:       newTestObjectMetaWithReplicaIndex("0"),
-			expectedIndex: 0,
-			expectedError: nil,
-		},
-		{
-			description:   "valid replica index 1",
-			objMeta:       newTestObjectMetaWithReplicaIndex("1"),
-			expectedIndex: 1,
-			expectedError: nil,
-		},
-		{
-			description:   "valid replica index 42",
-			objMeta:       newTestObjectMetaWithReplicaIndex("42"),
-			expectedIndex: 42,
-			expectedError: nil,
-		},
 		{
 			description: "valid replica index with multiple labels",
 			objMeta: newTestObjectMetaWithLabels(newLabelsWithReplicaIndexAndExtras("5", map[string]string{
@@ -118,46 +96,22 @@ func TestGetPodGangSetReplicaIndex(t *testing.T) {
 			expectedError: errNotFoundPodGangSetReplicaIndexLabel,
 		},
 		{
-			description:   "empty labels map",
-			objMeta:       newTestObjectMetaWithLabels(map[string]string{}),
-			expectedIndex: 0,
-			expectedError: errNotFoundPodGangSetReplicaIndexLabel,
-		},
-		{
-			description:   "invalid replica index - non-numeric string",
+			description:   "invalid replica index conversion",
 			objMeta:       newTestObjectMetaWithReplicaIndex("abc"),
 			expectedIndex: 0,
 			expectedError: errReplicaIndexIntConversion,
 		},
 		{
-			description:   "invalid replica index - empty string",
-			objMeta:       newTestObjectMetaWithReplicaIndex(""),
-			expectedIndex: 0,
-			expectedError: errReplicaIndexIntConversion,
-		},
-		{
-			description:   "invalid replica index - float string",
-			objMeta:       newTestObjectMetaWithReplicaIndex("1.5"),
-			expectedIndex: 0,
-			expectedError: errReplicaIndexIntConversion,
-		},
-		{
-			description:   "invalid replica index - negative number",
+			description:   "negative replica index allowed",
 			objMeta:       newTestObjectMetaWithReplicaIndex("-1"),
 			expectedIndex: -1,
 			expectedError: nil,
 		},
 		{
-			description:   "valid replica index - large number",
+			description:   "large replica index supported",
 			objMeta:       newTestObjectMetaWithReplicaIndex("9999"),
 			expectedIndex: 9999,
 			expectedError: nil,
-		},
-		{
-			description:   "invalid replica index - whitespace",
-			objMeta:       newTestObjectMetaWithReplicaIndex("  "),
-			expectedIndex: 0,
-			expectedError: errReplicaIndexIntConversion,
 		},
 	}
 

--- a/operator/internal/utils/kubernetes/labels_test.go
+++ b/operator/internal/utils/kubernetes/labels_test.go
@@ -1,0 +1,185 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package kubernetes
+
+import (
+	"errors"
+	"testing"
+
+	grovev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Test helper functions
+func newTestObjectMetaWithReplicaIndex(index string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      "test-resource",
+		Namespace: "test-ns",
+		Labels: map[string]string{
+			grovev1alpha1.LabelPodGangSetReplicaIndex: index,
+		},
+	}
+}
+
+func newTestObjectMetaWithLabels(labels map[string]string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      "test-resource",
+		Namespace: "test-ns",
+		Labels:    labels,
+	}
+}
+
+func newTestObjectMetaEmpty() metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      "test-resource",
+		Namespace: "test-ns",
+	}
+}
+
+func newTestObjectMetaNilLabels() metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      "test-resource",
+		Namespace: "test-ns",
+		Labels:    nil,
+	}
+}
+
+func newLabelsWithReplicaIndex(index string) map[string]string {
+	return map[string]string{
+		grovev1alpha1.LabelPodGangSetReplicaIndex: index,
+	}
+}
+
+func newLabelsWithReplicaIndexAndExtras(index string, extraLabels map[string]string) map[string]string {
+	labels := newLabelsWithReplicaIndex(index)
+	for k, v := range extraLabels {
+		labels[k] = v
+	}
+	return labels
+}
+
+func TestGetPodGangSetReplicaIndex(t *testing.T) {
+	testCases := []struct {
+		description   string
+		objMeta       metav1.ObjectMeta
+		expectedIndex int
+		expectedError error
+	}{
+		{
+			description:   "valid replica index 0",
+			objMeta:       newTestObjectMetaWithReplicaIndex("0"),
+			expectedIndex: 0,
+			expectedError: nil,
+		},
+		{
+			description:   "valid replica index 1",
+			objMeta:       newTestObjectMetaWithReplicaIndex("1"),
+			expectedIndex: 1,
+			expectedError: nil,
+		},
+		{
+			description:   "valid replica index 42",
+			objMeta:       newTestObjectMetaWithReplicaIndex("42"),
+			expectedIndex: 42,
+			expectedError: nil,
+		},
+		{
+			description: "valid replica index with multiple labels",
+			objMeta: newTestObjectMetaWithLabels(newLabelsWithReplicaIndexAndExtras("5", map[string]string{
+				"app":         "my-app",
+				"version":     "v1.0",
+				"environment": "test",
+			})),
+			expectedIndex: 5,
+			expectedError: nil,
+		},
+		{
+			description: "missing replica index label",
+			objMeta: newTestObjectMetaWithLabels(map[string]string{
+				"app":     "my-app",
+				"version": "v1.0",
+			}),
+			expectedIndex: 0,
+			expectedError: errNotFoundPodGangSetReplicaIndexLabel,
+		},
+		{
+			description:   "nil labels map",
+			objMeta:       newTestObjectMetaNilLabels(),
+			expectedIndex: 0,
+			expectedError: errNotFoundPodGangSetReplicaIndexLabel,
+		},
+		{
+			description:   "empty labels map",
+			objMeta:       newTestObjectMetaWithLabels(map[string]string{}),
+			expectedIndex: 0,
+			expectedError: errNotFoundPodGangSetReplicaIndexLabel,
+		},
+		{
+			description:   "invalid replica index - non-numeric string",
+			objMeta:       newTestObjectMetaWithReplicaIndex("abc"),
+			expectedIndex: 0,
+			expectedError: errReplicaIndexIntConversion,
+		},
+		{
+			description:   "invalid replica index - empty string",
+			objMeta:       newTestObjectMetaWithReplicaIndex(""),
+			expectedIndex: 0,
+			expectedError: errReplicaIndexIntConversion,
+		},
+		{
+			description:   "invalid replica index - float string",
+			objMeta:       newTestObjectMetaWithReplicaIndex("1.5"),
+			expectedIndex: 0,
+			expectedError: errReplicaIndexIntConversion,
+		},
+		{
+			description:   "invalid replica index - negative number",
+			objMeta:       newTestObjectMetaWithReplicaIndex("-1"),
+			expectedIndex: -1,
+			expectedError: nil,
+		},
+		{
+			description:   "valid replica index - large number",
+			objMeta:       newTestObjectMetaWithReplicaIndex("9999"),
+			expectedIndex: 9999,
+			expectedError: nil,
+		},
+		{
+			description:   "invalid replica index - whitespace",
+			objMeta:       newTestObjectMetaWithReplicaIndex("  "),
+			expectedIndex: 0,
+			expectedError: errReplicaIndexIntConversion,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			index, err := GetPodGangSetReplicaIndex(tc.objMeta)
+
+			if tc.expectedError != nil {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, tc.expectedError),
+					"expected error %v to contain %v", err, tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tc.expectedIndex, index)
+		})
+	}
+}

--- a/operator/internal/utils/kubernetes/labels_test.go
+++ b/operator/internal/utils/kubernetes/labels_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	grovev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/operator/internal/utils/kubernetes/objectmeta_test.go
+++ b/operator/internal/utils/kubernetes/objectmeta_test.go
@@ -19,6 +19,8 @@ package kubernetes
 import (
 	"testing"
 
+	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,6 +33,7 @@ const (
 	testPgsName      = "test-pgs"
 	testNamespace    = "test-ns"
 	testResourceName = "test-resource"
+	version          = "v1alpha1"
 )
 
 // Test helper functions
@@ -44,8 +47,8 @@ func newTestObjectMetaWithOwnerRefs(name, namespace string, ownerRefs ...metav1.
 
 func newTestOwnerReference(name string, uid types.UID, isController bool) metav1.OwnerReference {
 	return metav1.OwnerReference{
-		APIVersion: "v1",
-		Kind:       "PodGangSet",
+		APIVersion: version,
+		Kind:       grovecorev1alpha1.PodGangSetKind,
 		Name:       name,
 		UID:        uid,
 		Controller: ptr.To(isController),

--- a/operator/internal/utils/kubernetes/objectmeta_test.go
+++ b/operator/internal/utils/kubernetes/objectmeta_test.go
@@ -18,17 +18,59 @@ package kubernetes
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	testPgsName   = "test-pgs"
-	testNamespace = "test-ns"
+	testPgsName      = "test-pgs"
+	testNamespace    = "test-ns"
+	testResourceName = "test-resource"
 )
+
+// Test helper functions
+func newTestObjectMeta(name, namespace string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+	}
+}
+
+func newTestObjectMetaWithOwnerRefs(name, namespace string, ownerRefs ...metav1.OwnerReference) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:            name,
+		Namespace:       namespace,
+		OwnerReferences: ownerRefs,
+	}
+}
+
+func newTestObjectMetaWithDeletionTimestamp(name, namespace string, timestamp *metav1.Time) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:              name,
+		Namespace:         namespace,
+		DeletionTimestamp: timestamp,
+	}
+}
+
+func newTestOwnerReference(name string, uid types.UID, isController bool) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "PodGangSet",
+		Name:       name,
+		UID:        uid,
+		Controller: ptr.To(isController),
+	}
+}
+
+func newTestOwnerReferenceSimple(name string, isController bool) metav1.OwnerReference {
+	return newTestOwnerReference(name, uuid.NewUUID(), isController)
+}
 
 func TestGetDefaultLabelsForPodGangSetManagedResources(t *testing.T) {
 	labels := GetDefaultLabelsForPodGangSetManagedResources(testPgsName)
@@ -157,6 +199,184 @@ func TestFilterMapOwnedResourceNames(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			resourceNames := FilterMapOwnedResourceNames(tc.ownerObjMeta, tc.candidateResources)
 			assert.Equal(t, tc.expectedResourceNames, resourceNames)
+		})
+	}
+}
+
+func TestGetFirstOwnerName(t *testing.T) {
+	testCases := []struct {
+		description  string
+		resourceMeta metav1.ObjectMeta
+		expectedName string
+	}{
+		{
+			description: "should return first owner name when owner references exist",
+			resourceMeta: newTestObjectMetaWithOwnerRefs(testResourceName, testNamespace,
+				newTestOwnerReferenceSimple("first-owner", true),
+				newTestOwnerReferenceSimple("second-owner", false)),
+			expectedName: "first-owner",
+		},
+		{
+			description: "should return single owner name when only one owner exists",
+			resourceMeta: newTestObjectMetaWithOwnerRefs(testResourceName, testNamespace,
+				newTestOwnerReferenceSimple("only-owner", true)),
+			expectedName: "only-owner",
+		},
+		{
+			description:  "should return empty string when no owner references exist",
+			resourceMeta: newTestObjectMetaWithOwnerRefs(testResourceName, testNamespace),
+			expectedName: "",
+		},
+		{
+			description:  "should return empty string when owner references is nil",
+			resourceMeta: newTestObjectMeta(testResourceName, testNamespace),
+			expectedName: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := GetFirstOwnerName(tc.resourceMeta)
+			assert.Equal(t, tc.expectedName, result)
+		})
+	}
+}
+
+func TestGetObjectKeyFromObjectMeta(t *testing.T) {
+	testCases := []struct {
+		description string
+		objMeta     metav1.ObjectMeta
+		expectedKey client.ObjectKey
+	}{
+		{
+			description: "should create object key with namespace and name",
+			objMeta:     newTestObjectMeta(testResourceName, testNamespace),
+			expectedKey: client.ObjectKey{
+				Name:      testResourceName,
+				Namespace: testNamespace,
+			},
+		},
+		{
+			description: "should create object key with empty namespace for cluster-scoped resources",
+			objMeta:     newTestObjectMeta("test-cluster-resource", ""),
+			expectedKey: client.ObjectKey{
+				Name:      "test-cluster-resource",
+				Namespace: "",
+			},
+		},
+		{
+			description: "should create object key with empty name",
+			objMeta:     newTestObjectMeta("", testNamespace),
+			expectedKey: client.ObjectKey{
+				Name:      "",
+				Namespace: testNamespace,
+			},
+		},
+		{
+			description: "should create object key with both empty namespace and name",
+			objMeta:     newTestObjectMeta("", ""),
+			expectedKey: client.ObjectKey{
+				Name:      "",
+				Namespace: "",
+			},
+		},
+		{
+			description: "should create object key ignoring other metadata fields",
+			objMeta: metav1.ObjectMeta{
+				Name:      "test-resource",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					"app": "test",
+				},
+				Annotations: map[string]string{
+					"note": "test annotation",
+				},
+				UID:               uuid.NewUUID(),
+				ResourceVersion:   "123",
+				Generation:        1,
+				CreationTimestamp: metav1.Now(),
+			},
+			expectedKey: client.ObjectKey{
+				Name:      "test-resource",
+				Namespace: testNamespace,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := GetObjectKeyFromObjectMeta(tc.objMeta)
+			assert.Equal(t, tc.expectedKey, result)
+		})
+	}
+}
+
+func TestIsResourceTerminating(t *testing.T) {
+	now := metav1.Now()
+
+	testCases := []struct {
+		description    string
+		objMeta        metav1.ObjectMeta
+		expectedResult bool
+	}{
+		{
+			description:    "should return true when deletion timestamp is set",
+			objMeta:        newTestObjectMetaWithDeletionTimestamp(testResourceName, testNamespace, &now),
+			expectedResult: true,
+		},
+		{
+			description:    "should return false when deletion timestamp is nil",
+			objMeta:        newTestObjectMetaWithDeletionTimestamp(testResourceName, testNamespace, nil),
+			expectedResult: false,
+		},
+		{
+			description:    "should return false when deletion timestamp is not set",
+			objMeta:        newTestObjectMeta(testResourceName, testNamespace),
+			expectedResult: false,
+		},
+		{
+			description: "should return true when deletion timestamp is set with other metadata",
+			objMeta: metav1.ObjectMeta{
+				Name:      "test-resource",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					"app": "test",
+				},
+				Annotations: map[string]string{
+					"note": "test annotation",
+				},
+				Finalizers: []string{
+					"test.finalizer/cleanup",
+				},
+				DeletionTimestamp:          &now,
+				DeletionGracePeriodSeconds: ptr.To(int64(30)),
+			},
+			expectedResult: true,
+		},
+		{
+			description: "should return true when deletion timestamp is in the past",
+			objMeta: metav1.ObjectMeta{
+				Name:              "test-resource",
+				Namespace:         testNamespace,
+				DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+			},
+			expectedResult: true,
+		},
+		{
+			description: "should return true when deletion timestamp is in the future",
+			objMeta: metav1.ObjectMeta{
+				Name:              "test-resource",
+				Namespace:         testNamespace,
+				DeletionTimestamp: &metav1.Time{Time: time.Now().Add(5 * time.Minute)},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := IsResourceTerminating(tc.objMeta)
+			assert.Equal(t, tc.expectedResult, result)
 		})
 	}
 }

--- a/operator/internal/utils/kubernetes/objectmeta_test.go
+++ b/operator/internal/utils/kubernetes/objectmeta_test.go
@@ -34,26 +34,11 @@ const (
 )
 
 // Test helper functions
-func newTestObjectMeta(name, namespace string) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:      name,
-		Namespace: namespace,
-	}
-}
-
 func newTestObjectMetaWithOwnerRefs(name, namespace string, ownerRefs ...metav1.OwnerReference) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:            name,
 		Namespace:       namespace,
 		OwnerReferences: ownerRefs,
-	}
-}
-
-func newTestObjectMetaWithDeletionTimestamp(name, namespace string, timestamp *metav1.Time) metav1.ObjectMeta {
-	return metav1.ObjectMeta{
-		Name:              name,
-		Namespace:         namespace,
-		DeletionTimestamp: timestamp,
 	}
 }
 
@@ -188,8 +173,11 @@ func TestGetFirstOwnerName(t *testing.T) {
 			expectedName: "",
 		},
 		{
-			description:  "should return empty string when owner references is nil",
-			resourceMeta: newTestObjectMeta(testResourceName, testNamespace),
+			description: "should return empty string when owner references is nil",
+			resourceMeta: metav1.ObjectMeta{
+				Name:      testResourceName,
+				Namespace: testNamespace,
+			},
 			expectedName: "",
 		},
 	}
@@ -210,7 +198,10 @@ func TestGetObjectKeyFromObjectMeta(t *testing.T) {
 	}{
 		{
 			description: "should create object key with namespace and name",
-			objMeta:     newTestObjectMeta(testResourceName, testNamespace),
+			objMeta: metav1.ObjectMeta{
+				Name:      testResourceName,
+				Namespace: testNamespace,
+			},
 			expectedKey: client.ObjectKey{
 				Name:      testResourceName,
 				Namespace: testNamespace,
@@ -218,7 +209,10 @@ func TestGetObjectKeyFromObjectMeta(t *testing.T) {
 		},
 		{
 			description: "should create object key with empty namespace for cluster-scoped resources",
-			objMeta:     newTestObjectMeta("test-cluster-resource", ""),
+			objMeta: metav1.ObjectMeta{
+				Name:      "test-cluster-resource",
+				Namespace: "",
+			},
 			expectedKey: client.ObjectKey{
 				Name:      "test-cluster-resource",
 				Namespace: "",
@@ -226,7 +220,10 @@ func TestGetObjectKeyFromObjectMeta(t *testing.T) {
 		},
 		{
 			description: "should create object key with empty name",
-			objMeta:     newTestObjectMeta("", testNamespace),
+			objMeta: metav1.ObjectMeta{
+				Name:      "",
+				Namespace: testNamespace,
+			},
 			expectedKey: client.ObjectKey{
 				Name:      "",
 				Namespace: testNamespace,
@@ -234,7 +231,10 @@ func TestGetObjectKeyFromObjectMeta(t *testing.T) {
 		},
 		{
 			description: "should create object key with both empty namespace and name",
-			objMeta:     newTestObjectMeta("", ""),
+			objMeta: metav1.ObjectMeta{
+				Name:      "",
+				Namespace: "",
+			},
 			expectedKey: client.ObjectKey{
 				Name:      "",
 				Namespace: "",
@@ -280,18 +280,29 @@ func TestIsResourceTerminating(t *testing.T) {
 		expectedResult bool
 	}{
 		{
-			description:    "deletion timestamp set - resource terminating",
-			objMeta:        newTestObjectMetaWithDeletionTimestamp(testResourceName, testNamespace, &now),
+			description: "deletion timestamp set - resource terminating",
+			objMeta: metav1.ObjectMeta{
+				Name:              testResourceName,
+				Namespace:         testNamespace,
+				DeletionTimestamp: &now,
+			},
 			expectedResult: true,
 		},
 		{
-			description:    "deletion timestamp nil - resource not terminating",
-			objMeta:        newTestObjectMetaWithDeletionTimestamp(testResourceName, testNamespace, nil),
+			description: "deletion timestamp nil - resource not terminating",
+			objMeta: metav1.ObjectMeta{
+				Name:              testResourceName,
+				Namespace:         testNamespace,
+				DeletionTimestamp: nil,
+			},
 			expectedResult: false,
 		},
 		{
-			description:    "no deletion timestamp - resource not terminating",
-			objMeta:        newTestObjectMeta(testResourceName, testNamespace),
+			description: "no deletion timestamp - resource not terminating",
+			objMeta: metav1.ObjectMeta{
+				Name:      testResourceName,
+				Namespace: testNamespace,
+			},
 			expectedResult: false,
 		},
 		{

--- a/operator/internal/utils/kubernetes/webhook_test.go
+++ b/operator/internal/utils/kubernetes/webhook_test.go
@@ -75,6 +75,18 @@ func TestCreateObjectKeyForCreateWebhooks(t *testing.T) {
 			admissionReq:    admission.Request{},
 			expectObjectKey: client.ObjectKey{Namespace: "", Name: testObjGenerateName},
 		},
+		{
+			description:     "object with empty name and generateName falls back to empty",
+			obj:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "", GenerateName: ""}},
+			admissionReq:    admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Namespace: testObjNamespace}},
+			expectObjectKey: client.ObjectKey{Name: "", Namespace: testObjNamespace},
+		},
+		{
+			description:     "object with nil metadata uses admission request namespace",
+			obj:             &corev1.Pod{ObjectMeta: metav1.ObjectMeta{}},
+			admissionReq:    admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Namespace: testObjNamespace}},
+			expectObjectKey: client.ObjectKey{Name: "", Namespace: testObjNamespace},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/operator/internal/utils/miscellaneous_test.go
+++ b/operator/internal/utils/miscellaneous_test.go
@@ -223,7 +223,7 @@ func TestOnlyOneIsNilWithDifferentTypes(t *testing.T) {
 		{
 			description: "struct pointers - both nil should return false",
 			testFunc: func() bool {
-				type TestStruct struct{ value string }
+				type TestStruct struct{ _ string }
 				return OnlyOneIsNil((*TestStruct)(nil), (*TestStruct)(nil))
 			},
 			expected: false,
@@ -231,24 +231,24 @@ func TestOnlyOneIsNilWithDifferentTypes(t *testing.T) {
 		{
 			description: "struct pointers - first nil should return true",
 			testFunc: func() bool {
-				type TestStruct struct{ value string }
-				return OnlyOneIsNil((*TestStruct)(nil), &TestStruct{value: "test"})
+				type TestStruct struct{ _ string }
+				return OnlyOneIsNil((*TestStruct)(nil), &TestStruct{})
 			},
 			expected: true,
 		},
 		{
 			description: "struct pointers - second nil should return true",
 			testFunc: func() bool {
-				type TestStruct struct{ value string }
-				return OnlyOneIsNil(&TestStruct{value: "test"}, (*TestStruct)(nil))
+				type TestStruct struct{ _ string }
+				return OnlyOneIsNil(&TestStruct{}, (*TestStruct)(nil))
 			},
 			expected: true,
 		},
 		{
 			description: "struct pointers - both non-nil should return false",
 			testFunc: func() bool {
-				type TestStruct struct{ value string }
-				return OnlyOneIsNil(&TestStruct{value: "test1"}, &TestStruct{value: "test2"})
+				type TestStruct struct{ _ string }
+				return OnlyOneIsNil(&TestStruct{}, &TestStruct{})
 			},
 			expected: false,
 		},

--- a/operator/internal/utils/miscellaneous_test.go
+++ b/operator/internal/utils/miscellaneous_test.go
@@ -1,0 +1,263 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+type CustomString string
+type AnotherStringType string
+
+func TestIsEmptyStringType(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       interface{}
+		expected    bool
+	}{
+		{
+			description: "empty string should return true",
+			input:       "",
+			expected:    true,
+		},
+		{
+			description: "string with only spaces should return true",
+			input:       "   ",
+			expected:    true,
+		},
+		{
+			description: "string with only tabs should return true",
+			input:       "\t\t",
+			expected:    true,
+		},
+		{
+			description: "string with only newlines should return true",
+			input:       "\n\n",
+			expected:    true,
+		},
+		{
+			description: "string with mixed whitespace should return true",
+			input:       " \t\n ",
+			expected:    true,
+		},
+		{
+			description: "string with actual content should return false",
+			input:       "hello",
+			expected:    false,
+		},
+		{
+			description: "string with content and leading/trailing spaces should return false",
+			input:       "  hello  ",
+			expected:    false,
+		},
+		{
+			description: "string with content and mixed whitespace should return false",
+			input:       "\t hello \n",
+			expected:    false,
+		},
+		{
+			description: "single character string should return false",
+			input:       "a",
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			switch v := tc.input.(type) {
+			case string:
+				assert.Equal(t, tc.expected, IsEmptyStringType(v))
+			}
+		})
+	}
+}
+
+func TestIsEmptyStringTypeWithCustomTypes(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       interface{}
+		expected    bool
+	}{
+		{
+			description: "empty CustomString should return true",
+			input:       CustomString(""),
+			expected:    true,
+		},
+		{
+			description: "CustomString with spaces should return true",
+			input:       CustomString("   "),
+			expected:    true,
+		},
+		{
+			description: "CustomString with content should return false",
+			input:       CustomString("test"),
+			expected:    false,
+		},
+		{
+			description: "empty AnotherStringType should return true",
+			input:       AnotherStringType(""),
+			expected:    true,
+		},
+		{
+			description: "AnotherStringType with tabs should return true",
+			input:       AnotherStringType("\t\t"),
+			expected:    true,
+		},
+		{
+			description: "AnotherStringType with content should return false",
+			input:       AnotherStringType("content"),
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			switch v := tc.input.(type) {
+			case CustomString:
+				assert.Equal(t, tc.expected, IsEmptyStringType(v))
+			case AnotherStringType:
+				assert.Equal(t, tc.expected, IsEmptyStringType(v))
+			}
+		})
+	}
+}
+
+func TestOnlyOneIsNil(t *testing.T) {
+	testCases := []struct {
+		description string
+		objA        interface{}
+		objB        interface{}
+		expected    bool
+	}{
+		{
+			description: "both nil should return false",
+			objA:        (*string)(nil),
+			objB:        (*string)(nil),
+			expected:    false,
+		},
+		{
+			description: "first nil, second non-nil should return true",
+			objA:        (*string)(nil),
+			objB:        ptr.To("test"),
+			expected:    true,
+		},
+		{
+			description: "first non-nil, second nil should return true",
+			objA:        ptr.To("test"),
+			objB:        (*string)(nil),
+			expected:    true,
+		},
+		{
+			description: "both non-nil should return false",
+			objA:        ptr.To("test1"),
+			objB:        ptr.To("test2"),
+			expected:    false,
+		},
+		{
+			description: "both non-nil with same value should return false",
+			objA:        ptr.To("same"),
+			objB:        ptr.To("same"),
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := OnlyOneIsNil(tc.objA.(*string), tc.objB.(*string))
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestOnlyOneIsNilWithDifferentTypes(t *testing.T) {
+	testCases := []struct {
+		description string
+		testFunc    func() bool
+		expected    bool
+	}{
+		{
+			description: "int pointers - both nil should return false",
+			testFunc: func() bool {
+				return OnlyOneIsNil((*int)(nil), (*int)(nil))
+			},
+			expected: false,
+		},
+		{
+			description: "int pointers - first nil should return true",
+			testFunc: func() bool {
+				return OnlyOneIsNil((*int)(nil), ptr.To(42))
+			},
+			expected: true,
+		},
+		{
+			description: "int pointers - second nil should return true",
+			testFunc: func() bool {
+				return OnlyOneIsNil(ptr.To(42), (*int)(nil))
+			},
+			expected: true,
+		},
+		{
+			description: "int pointers - both non-nil should return false",
+			testFunc: func() bool {
+				return OnlyOneIsNil(ptr.To(42), ptr.To(84))
+			},
+			expected: false,
+		},
+		{
+			description: "struct pointers - both nil should return false",
+			testFunc: func() bool {
+				type TestStruct struct{ value string }
+				return OnlyOneIsNil((*TestStruct)(nil), (*TestStruct)(nil))
+			},
+			expected: false,
+		},
+		{
+			description: "struct pointers - first nil should return true",
+			testFunc: func() bool {
+				type TestStruct struct{ value string }
+				return OnlyOneIsNil((*TestStruct)(nil), &TestStruct{value: "test"})
+			},
+			expected: true,
+		},
+		{
+			description: "struct pointers - second nil should return true",
+			testFunc: func() bool {
+				type TestStruct struct{ value string }
+				return OnlyOneIsNil(&TestStruct{value: "test"}, (*TestStruct)(nil))
+			},
+			expected: true,
+		},
+		{
+			description: "struct pointers - both non-nil should return false",
+			testFunc: func() bool {
+				type TestStruct struct{ value string }
+				return OnlyOneIsNil(&TestStruct{value: "test1"}, &TestStruct{value: "test2"})
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := tc.testFunc()
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/operator/internal/utils/miscellaneous_test.go
+++ b/operator/internal/utils/miscellaneous_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 type CustomString string
+
 type AnotherStringType string
 
 func TestIsEmptyStringType(t *testing.T) {

--- a/operator/internal/utils/miscellaneous_test.go
+++ b/operator/internal/utils/miscellaneous_test.go
@@ -73,11 +73,6 @@ func TestIsEmptyStringType(t *testing.T) {
 			input:       "\t hello \n",
 			expected:    false,
 		},
-		{
-			description: "single character string should return false",
-			input:       "a",
-			expected:    false,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/operator/internal/utils/miscellaneous_test.go
+++ b/operator/internal/utils/miscellaneous_test.go
@@ -217,30 +217,6 @@ func TestOnlyOneIsNilWithDifferentTypes(t *testing.T) {
 			expected: false,
 		},
 		{
-			description: "struct pointers - both nil should return false",
-			testFunc: func() bool {
-				type TestStruct struct{ _ string }
-				return OnlyOneIsNil((*TestStruct)(nil), (*TestStruct)(nil))
-			},
-			expected: false,
-		},
-		{
-			description: "struct pointers - first nil should return true",
-			testFunc: func() bool {
-				type TestStruct struct{ _ string }
-				return OnlyOneIsNil((*TestStruct)(nil), &TestStruct{})
-			},
-			expected: true,
-		},
-		{
-			description: "struct pointers - second nil should return true",
-			testFunc: func() bool {
-				type TestStruct struct{ _ string }
-				return OnlyOneIsNil(&TestStruct{}, (*TestStruct)(nil))
-			},
-			expected: true,
-		},
-		{
 			description: "struct pointers - both non-nil should return false",
 			testFunc: func() bool {
 				type TestStruct struct{ _ string }


### PR DESCRIPTION
This pull request adds comprehensive unit tests for utility functions in the operator's internal controller and Kubernetes condition handling modules. The new tests cover various scenarios for owner reference checks, label management, error handling in reconciliation, and Kubernetes condition status utilities to ensure correctness and robustness.

**Controller utility tests:**

* Added `managedresource_test.go` with thorough tests for `HasExpectedOwner`, `IsManagedByGrove`, and `IsManagedPodClique` functions, covering edge cases for owner references and label checks.
* Added `reconciler_test.go` with tests for error handling helpers `ShouldRequeueAfter` and `ShouldContinueReconcileAndRequeue`, validating behavior for different error codes and types.

**Kubernetes condition utility tests:**

* Introduced helper functions and condition builders to simplify test case creation for Kubernetes conditions in `conditions_test.go`.
* Added tests for `IsConditionTrue`, `IsConditionUnknown`, and `GetConditionStatus` functions, ensuring correct detection and status retrieval for various condition scenarios.