### PR TITLE
Fixes overwriting of pod.spec.serviceAccountName field set by the user

### DIFF
--- a/operator/api/core/v1alpha1/namegen.go
+++ b/operator/api/core/v1alpha1/namegen.go
@@ -39,20 +39,29 @@ func GenerateHeadlessServiceAddress(pgsNameReplica ResourceNameReplica, namespac
 	return fmt.Sprintf("%s.%s.svc.cluster.local", GenerateHeadlessServiceName(pgsNameReplica), namespace)
 }
 
-// GeneratePodRoleName generates a Pod role name based on the PodGangSet name.
-// This role will be associated to all Pods within a PodGangSet.
+// GeneratePodRoleName generates a Pod role name.
+// This role will be associated to an init container within each Pod for a PodGangSet.
+// The init container is created by the operator and is responsible for ensuring start-up order amongst PodCliques.
 func GeneratePodRoleName(pgsName string) string {
 	return fmt.Sprintf("%s:pgs:%s", SchemeGroupVersion.Group, pgsName)
 }
 
-// GeneratePodRoleBindingName generates a Pod role binding name based on the PodGangSet name.
+// GeneratePodRoleBindingName generates a role binding name. The role binding will bind the
+// role to the service account that are created for the init container responsible for ensuring start-up order amongst PodCliques.
 func GeneratePodRoleBindingName(pgsName string) string {
 	return fmt.Sprintf("%s:pgs:%s", SchemeGroupVersion.Group, pgsName)
 }
 
-// GeneratePodServiceAccountName generates a Pod service account used by all the Pods within a PodGangSet.
+// GeneratePodServiceAccountName generates a Pod service account used by all the init containers
+// within the PodGangSet (one per pod) that are responsible for ensuring start-up order amongst PodCliques.
 func GeneratePodServiceAccountName(pgsName string) string {
 	return pgsName
+}
+
+// GeneratePodInitContainerSecretName generates a Secret name that will be mounted onto the init container
+// responsible for ensuring start-up order amongst PodCliques.
+func GeneratePodInitContainerSecretName(pgsName string) string {
+	return fmt.Sprintf("%s-initc", pgsName)
 }
 
 // GeneratePodCliqueName generates a PodClique name based on the PodGangSet name, replica index, and PodCliqueTemplate name.

--- a/operator/api/core/v1alpha1/namegen.go
+++ b/operator/api/core/v1alpha1/namegen.go
@@ -58,10 +58,10 @@ func GeneratePodServiceAccountName(pgsName string) string {
 	return pgsName
 }
 
-// GeneratePodInitContainerSecretName generates a Secret name that will be mounted onto the init container
+// GenerateInitContainerSATokenSecretName generates a Secret name containing a service account token that will be mounted onto the init container
 // responsible for ensuring start-up order amongst PodCliques.
-func GeneratePodInitContainerSecretName(pgsName string) string {
-	return fmt.Sprintf("%s-initc", pgsName)
+func GenerateInitContainerSATokenSecretName(pgsName string) string {
+	return fmt.Sprintf("%s-initc-sa-token-secret", pgsName)
 }
 
 // GeneratePodCliqueName generates a PodClique name based on the PodGangSet name, replica index, and PodCliqueTemplate name.

--- a/operator/charts/templates/clusterrole.yaml
+++ b/operator/charts/templates/clusterrole.yaml
@@ -83,6 +83,17 @@ rules:
   - watch
   - patch
 - apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - create
+    - get
+    - list
+    - patch
+    - delete
+    - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles

--- a/operator/initc/cmd/main.go
+++ b/operator/initc/cmd/main.go
@@ -56,7 +56,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := podCliqueState.WaitForReady(ctx, log); err != nil {
+	if err = podCliqueState.WaitForReady(ctx, log); err != nil {
 		log.Error(err, "Failed to wait for all parent PodCliques")
 		os.Exit(1)
 	}

--- a/operator/internal/common/constants.go
+++ b/operator/internal/common/constants.go
@@ -21,6 +21,6 @@ const (
 	PodGangNameFileName = "podgangname"
 	// PodNamespaceFileName is the name of the file that contains the namespace in which the pod is running.
 	PodNamespaceFileName = "namespace"
-	// VolumeMountPathPodInfo contains the file path at which the downward API volume is attached.
+	// VolumeMountPathPodInfo contains the file path at which the downward API volume is mounted.
 	VolumeMountPathPodInfo = "/var/grove/pod-info"
 )

--- a/operator/internal/component/podclique/pod/initcontainer.go
+++ b/operator/internal/component/podclique/pod/initcontainer.go
@@ -1,0 +1,151 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package pod
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	"github.com/NVIDIA/grove/operator/internal/common"
+	"github.com/NVIDIA/grove/operator/internal/component"
+	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
+	"github.com/NVIDIA/grove/operator/internal/version"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	// envVarInitContainerImage stores the environment variable which is read to find the image for the init-container.
+	// The environment variable should only store the registry and repository of the init-container. It should not contain any tag.
+	envVarInitContainerImage string = "GROVE_INIT_CONTAINER_IMAGE"
+	// initContainerName is the name of the init container.
+	initContainerName = "grove-initc"
+	// serviceAccountTokenSecretVolumeName is the name of the volume that mounts the service account token secret.
+	serviceAccountTokenSecretVolumeName = "sa-token-secret-vol"
+	// podInfoVolumeName is the name of the downwardAPI volume that passes the pod information to the init container.
+	podInfoVolumeName = "pod-info-vol"
+	// volumeMountPathServiceAccount is the base path where token and CA.cert for the service account will be placed.
+	volumeMountPathServiceAccount = "/var/run/secrets/kubernetes.io/serviceaccount"
+)
+
+func configurePodInitContainer(pgs *grovecorev1alpha1.PodGangSet, pclq *grovecorev1alpha1.PodClique, pod *corev1.Pod) error {
+	addServiceAccountTokenSecretVolume(pgs.Name, pod)
+	addPodInfoVolume(pod)
+	return addInitContainer(pgs, pclq, pod)
+}
+
+func addServiceAccountTokenSecretVolume(pgsName string, pod *corev1.Pod) {
+	saTokenSecretVol := corev1.Volume{
+		Name: serviceAccountTokenSecretVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  grovecorev1alpha1.GeneratePodInitContainerSecretName(pgsName),
+				DefaultMode: ptr.To[int32](420),
+			},
+		},
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, saTokenSecretVol)
+}
+
+func addPodInfoVolume(pod *corev1.Pod) {
+	podInfoVol := corev1.Volume{
+		Name: podInfoVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			DownwardAPI: &corev1.DownwardAPIVolumeSource{
+				Items: []corev1.DownwardAPIVolumeFile{
+					{
+						Path: common.PodNamespaceFileName,
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.namespace",
+						},
+					},
+					{
+						Path: common.PodGangNameFileName,
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: fmt.Sprintf("metadata.labels['%s']", grovecorev1alpha1.LabelPodGang),
+						},
+					},
+				},
+			},
+		},
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, podInfoVol)
+}
+
+func addInitContainer(pgs *grovecorev1alpha1.PodGangSet, pclq *grovecorev1alpha1.PodClique, pod *corev1.Pod) error {
+	image, err := getInitContainerImage()
+	if err != nil {
+		return err
+	}
+	args, err := generateArgsForInitContainer(pgs, pclq)
+	if err != nil {
+		return err
+	}
+
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
+		Name:  initContainerName,
+		Image: fmt.Sprintf("%s:%s", image, version.Get().GitVersion),
+		Args:  args,
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      podInfoVolumeName,
+				ReadOnly:  true,
+				MountPath: common.VolumeMountPathPodInfo,
+			},
+			{
+				Name:      serviceAccountTokenSecretVolumeName,
+				ReadOnly:  true,
+				MountPath: volumeMountPathServiceAccount,
+			},
+		},
+	})
+	return nil
+}
+
+func getInitContainerImage() (string, error) {
+	initContainerImage, ok := os.LookupEnv(envVarInitContainerImage)
+	if !ok {
+		return "", groveerr.New(
+			errCodeInitContainerImageEnvVarMissing,
+			component.OperationSync,
+			fmt.Sprintf("environment variable %s specifying the init-container image is missing", envVarInitContainerImage),
+		)
+	}
+	return initContainerImage, nil
+}
+
+func generateArgsForInitContainer(pgs *grovecorev1alpha1.PodGangSet, pclq *grovecorev1alpha1.PodClique) ([]string, error) {
+	args := make([]string, 0)
+	for _, parentCliqueFQN := range pclq.Spec.StartsAfter {
+		parentCliqueTemplateSpec, ok := lo.Find(pgs.Spec.Template.Cliques, func(templateSpec *grovecorev1alpha1.PodCliqueTemplateSpec) bool {
+			return strings.HasSuffix(parentCliqueFQN, templateSpec.Name)
+		})
+		if !ok {
+			return nil, groveerr.New(
+				errCodeMissingPodCliqueTemplate,
+				component.OperationSync,
+				fmt.Sprintf("PodClique %s specified in startsAfter is not present in the templates", parentCliqueFQN),
+			)
+		}
+		args = append(args, fmt.Sprintf("--podcliques=%s:%d", parentCliqueFQN, *parentCliqueTemplateSpec.Spec.MinAvailable))
+	}
+	return args, nil
+}

--- a/operator/internal/component/podclique/pod/initcontainer.go
+++ b/operator/internal/component/podclique/pod/initcontainer.go
@@ -57,7 +57,7 @@ func addServiceAccountTokenSecretVolume(pgsName string, pod *corev1.Pod) {
 		Name: serviceAccountTokenSecretVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName:  grovecorev1alpha1.GeneratePodInitContainerSecretName(pgsName),
+				SecretName:  grovecorev1alpha1.GenerateInitContainerSATokenSecretName(pgsName),
 				DefaultMode: ptr.To[int32](420),
 			},
 		},

--- a/operator/internal/component/podgangset/registry.go
+++ b/operator/internal/component/podgangset/registry.go
@@ -25,6 +25,7 @@ import (
 	"github.com/NVIDIA/grove/operator/internal/component/podgangset/podgang"
 	"github.com/NVIDIA/grove/operator/internal/component/podgangset/role"
 	"github.com/NVIDIA/grove/operator/internal/component/podgangset/rolebinding"
+	"github.com/NVIDIA/grove/operator/internal/component/podgangset/satokensecret"
 	"github.com/NVIDIA/grove/operator/internal/component/podgangset/service"
 	"github.com/NVIDIA/grove/operator/internal/component/podgangset/serviceaccount"
 
@@ -41,6 +42,7 @@ func CreateOperatorRegistry(mgr manager.Manager, eventRecorder record.EventRecor
 	reg.Register(component.KindRole, role.New(cl, mgr.GetScheme()))
 	reg.Register(component.KindRoleBinding, rolebinding.New(cl, mgr.GetScheme()))
 	reg.Register(component.KindServiceAccount, serviceaccount.New(cl, mgr.GetScheme()))
+	reg.Register(component.KindServiceAccountTokenSecret, satokensecret.New(cl, mgr.GetScheme()))
 	reg.Register(component.KindPodCliqueScalingGroup, podcliquescalinggroup.New(cl, mgr.GetScheme(), eventRecorder))
 	reg.Register(component.KindHorizontalPodAutoscaler, hpa.New(cl, mgr.GetScheme()))
 	reg.Register(component.KindPodGang, podgang.New(cl, mgr.GetScheme(), eventRecorder))

--- a/operator/internal/component/podgangset/satokensecret/satokensecret.go
+++ b/operator/internal/component/podgangset/satokensecret/satokensecret.go
@@ -1,0 +1,167 @@
+// /*
+// Copyright 2025 The Grove Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// */
+
+package satokensecret
+
+import (
+	"context"
+	"fmt"
+
+	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	"github.com/NVIDIA/grove/operator/internal/component"
+	groveerr "github.com/NVIDIA/grove/operator/internal/errors"
+	k8sutils "github.com/NVIDIA/grove/operator/internal/utils/kubernetes"
+
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	errCodeGetSecret              grovecorev1alpha1.ErrorCode = "ERR_GET_SECRET"
+	errCodeSetControllerReference grovecorev1alpha1.ErrorCode = "ERR_SET_CONTROLLER_REFERENCE"
+	errCodeCreateSecret           grovecorev1alpha1.ErrorCode = "ERR_CREATE_SECRET"
+	errCodeDeleteSecret           grovecorev1alpha1.ErrorCode = "ERR_DELETE_SECRET"
+)
+
+type _resource struct {
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// New creates an instance of Secret component operator.
+func New(client client.Client, scheme *runtime.Scheme) component.Operator[grovecorev1alpha1.PodGangSet] {
+	return &_resource{
+		client: client,
+		scheme: scheme,
+	}
+}
+
+func (r _resource) GetExistingResourceNames(ctx context.Context, _ logr.Logger, pgsObjMeta metav1.ObjectMeta) ([]string, error) {
+	secretNames := make([]string, 0, 1)
+	objKey := getObjectKey(pgsObjMeta)
+	partialObjMeta, err := k8sutils.GetExistingPartialObjectMetadata(ctx, r.client, corev1.SchemeGroupVersion.WithKind("Secret"), objKey)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return secretNames, nil
+		}
+		return nil, groveerr.WrapError(err,
+			errCodeGetSecret,
+			component.OperationGetExistingResourceNames,
+			fmt.Sprintf("Error getting Secret: %v for PodGangSet: %v", objKey, k8sutils.GetObjectKeyFromObjectMeta(pgsObjMeta)),
+		)
+	}
+	if metav1.IsControlledBy(partialObjMeta, &pgsObjMeta) {
+		secretNames = append(secretNames, partialObjMeta.Name)
+	}
+	return secretNames, nil
+}
+
+func (r _resource) Sync(ctx context.Context, logger logr.Logger, pgs *grovecorev1alpha1.PodGangSet) error {
+	pgsObjKey := client.ObjectKeyFromObject(pgs)
+	existingSecretNames, err := r.GetExistingResourceNames(ctx, logger, pgs.ObjectMeta)
+	if err != nil {
+		return groveerr.WrapError(err,
+			errCodeGetSecret,
+			component.OperationSync,
+			fmt.Sprintf("Error getting existing satokensecret names for PodGangSet: %v", pgsObjKey),
+		)
+	}
+	if len(existingSecretNames) > 0 {
+		logger.Info("Secret already exists, skipping creation", "existingSecret", existingSecretNames[0])
+		return nil
+	}
+	objKey := getObjectKey(pgs.ObjectMeta)
+	secret := emptySecret(objKey)
+	if err = r.buildResource(pgs, secret); err != nil {
+		return err
+	}
+	if err = client.IgnoreAlreadyExists(r.client.Create(ctx, secret)); err != nil {
+		return groveerr.WrapError(err,
+			errCodeCreateSecret,
+			component.OperationSync,
+			fmt.Sprintf("Error creating satokensecret: %v for PodGangSet: %v", objKey, pgsObjKey),
+		)
+	}
+	logger.Info("Created Secret", "objectKey", objKey)
+	return nil
+}
+
+func (r _resource) Delete(ctx context.Context, logger logr.Logger, pgsObjMeta metav1.ObjectMeta) error {
+	objectKey := getObjectKey(pgsObjMeta)
+	logger.Info("Triggering delete of Secret", "objectKey", objectKey)
+	if err := r.client.Delete(ctx, emptySecret(objectKey)); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("Secret not found", "objectKey", objectKey)
+			return nil
+		}
+		return groveerr.WrapError(err,
+			errCodeDeleteSecret,
+			component.OperationDelete,
+			fmt.Sprintf("Error deleting satokensecret: %v for PodGangSet: %v", objectKey, k8sutils.GetObjectKeyFromObjectMeta(pgsObjMeta)),
+		)
+	}
+	logger.Info("Deleted Secret", "objectKey", objectKey)
+	return nil
+}
+
+func (r _resource) buildResource(pgs *grovecorev1alpha1.PodGangSet, secret *corev1.Secret) error {
+	secret.Labels = getLabels(pgs.Name, secret.Name)
+	if err := controllerutil.SetControllerReference(pgs, secret, r.scheme); err != nil {
+		return groveerr.WrapError(err,
+			errCodeSetControllerReference,
+			component.OperationSync,
+			fmt.Sprintf("Error setting controller reference for satokensecret: %v", client.ObjectKeyFromObject(secret)),
+		)
+	}
+	secret.Type = corev1.SecretTypeServiceAccountToken
+	secret.Annotations = map[string]string{
+		corev1.ServiceAccountNameKey: grovecorev1alpha1.GeneratePodServiceAccountName(pgs.Name),
+	}
+	return nil
+}
+
+func getLabels(pgsName, secretName string) map[string]string {
+	secretLabels := map[string]string{
+		grovecorev1alpha1.LabelComponentKey: component.NameServiceAccountTokenSecret,
+		grovecorev1alpha1.LabelAppNameKey:   secretName,
+	}
+	return lo.Assign(
+		k8sutils.GetDefaultLabelsForPodGangSetManagedResources(pgsName),
+		secretLabels,
+	)
+}
+
+func getObjectKey(pgsObjMeta metav1.ObjectMeta) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      grovecorev1alpha1.GeneratePodInitContainerSecretName(pgsObjMeta.Name),
+		Namespace: pgsObjMeta.Namespace,
+	}
+}
+
+func emptySecret(objKey client.ObjectKey) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objKey.Name,
+			Namespace: objKey.Namespace,
+		},
+	}
+}

--- a/operator/internal/component/podgangset/satokensecret/satokensecret.go
+++ b/operator/internal/component/podgangset/satokensecret/satokensecret.go
@@ -152,7 +152,7 @@ func getLabels(pgsName, secretName string) map[string]string {
 
 func getObjectKey(pgsObjMeta metav1.ObjectMeta) client.ObjectKey {
 	return client.ObjectKey{
-		Name:      grovecorev1alpha1.GeneratePodInitContainerSecretName(pgsObjMeta.Name),
+		Name:      grovecorev1alpha1.GenerateInitContainerSATokenSecretName(pgsObjMeta.Name),
 		Namespace: pgsObjMeta.Namespace,
 	}
 }

--- a/operator/internal/component/types.go
+++ b/operator/internal/component/types.go
@@ -53,6 +53,8 @@ const (
 	NamePodRoleBinding = "pod-role-binding"
 	// NamePodServiceAccount is the component name for a ServiceAccount that is used by all Pods that are created for a PodGangSet.
 	NamePodServiceAccount = "pod-service-account"
+	// NameServiceAccountTokenSecret is the component name for a Secret for generating service account token that is used by start-up order enforcing init container in each Pod for a PodGangSet.
+	NameServiceAccountTokenSecret = "pod-sa-token-secret"
 	// NamePodCliqueScalingGroup is the component name for a PodCliqueScalingGroup resource.
 	NamePodCliqueScalingGroup = "pgs-pod-clique-scaling-group"
 	// NameHorizontalPodAutoscaler is the component name for a HorizontalPodAutoscaler that is created for a PodGangSet.
@@ -82,8 +84,6 @@ type Operator[T GroveCustomResourceType] interface {
 type Kind string
 
 const (
-	// KindPodGangSet indicates that kind of the component is a PodGangSet.
-	KindPodGangSet Kind = "PodGangSet"
 	// KindPodClique indicates that the resource is a PodClique.
 	KindPodClique Kind = "PodClique"
 	// KindServiceAccount indicates that the resource is a ServiceAccount.
@@ -92,16 +92,14 @@ const (
 	KindRole Kind = "Role"
 	// KindRoleBinding indicates that the resource is a RoleBinding.
 	KindRoleBinding Kind = "RoleBinding"
+	// KindServiceAccountTokenSecret indicates that the resource is a Secret to generate ServiceAccount token.
+	KindServiceAccountTokenSecret Kind = "ServiceAccountTokenSecret"
 	// KindHeadlessService indicates that the resource is a headless Service.
 	KindHeadlessService Kind = "HeadlessService"
-	// KindNetworkPolicy indicates that the resource is a NetworkPolicy.
-	KindNetworkPolicy Kind = "NetworkPolicy"
 	// KindHorizontalPodAutoscaler indicates that the resource is a HorizontalPodAutoscaler.
 	KindHorizontalPodAutoscaler Kind = "HorizontalPodAutoscaler"
 	// KindPod indicates that the resource is a Pod.
 	KindPod Kind = "Pod"
-	// KindPersistentVolumeClaim indicates that the resource is a PersistentVolumeClaim.
-	KindPersistentVolumeClaim Kind = "PersistentVolumeClaim"
 	// KindPodCliqueScalingGroup indicates that the resource is a PodCliqueScalingGroup.
 	KindPodCliqueScalingGroup Kind = "PodCliqueScalingGroup"
 	// KindPodGang indicates that the resource is a PodGang.

--- a/operator/internal/controller/podgangset/reconcilespec.go
+++ b/operator/internal/controller/podgangset/reconcilespec.go
@@ -129,6 +129,7 @@ func getOrderedKindsForSync() []component.Kind {
 		component.KindServiceAccount,
 		component.KindRole,
 		component.KindRoleBinding,
+		component.KindServiceAccountTokenSecret,
 		component.KindHeadlessService,
 		component.KindHorizontalPodAutoscaler,
 		component.KindPodClique,

--- a/operator/internal/utils/kubernetes/partialobjectmeta.go
+++ b/operator/internal/utils/kubernetes/partialobjectmeta.go
@@ -24,16 +24,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ListExistingPartialObjectMetadata gets the PartialObjectMetadata for a GVK in a given namespace and matching labels.
+// ListExistingPartialObjectMetadata gets the slice of PartialObjectMetadata for a GVK in a given namespace and matching labels.
 func ListExistingPartialObjectMetadata(ctx context.Context, cl client.Client, gvk schema.GroupVersionKind, ownerObjMeta metav1.ObjectMeta, selectorLabels map[string]string) ([]metav1.PartialObjectMetadata, error) {
-	objMetaList := &metav1.PartialObjectMetadataList{}
-	objMetaList.SetGroupVersionKind(gvk)
+	partialObjMetaList := &metav1.PartialObjectMetadataList{}
+	partialObjMetaList.SetGroupVersionKind(gvk)
 	if err := cl.List(ctx,
-		objMetaList,
+		partialObjMetaList,
 		client.InNamespace(ownerObjMeta.Namespace),
 		client.MatchingLabels(selectorLabels),
 	); err != nil {
 		return nil, err
 	}
-	return objMetaList.Items, nil
+	return partialObjMetaList.Items, nil
+}
+
+// GetExistingPartialObjectMetadata gets the PartialObjectMetadata for the given GVK
+func GetExistingPartialObjectMetadata(ctx context.Context, cl client.Client, gvk schema.GroupVersionKind, objKey client.ObjectKey) (*metav1.PartialObjectMetadata, error) {
+	partialObjMeta := &metav1.PartialObjectMetadata{}
+	partialObjMeta.SetGroupVersionKind(gvk)
+	if err := cl.Get(ctx, objKey, partialObjMeta); err != nil {
+		return nil, err
+	}
+	return partialObjMeta, nil
 }


### PR DESCRIPTION
Fixes #141 
This PR introduces the following changes:

- Fixed overwriting of pod.spec.serviceAccountName field set by the user.
- Introduced a satokensecret component which will host a long lived statically generated service account token to be used by the init container.
- Added additional permissions to ClusterRole for the operator to additional watch/list/get/patch/delete corev1.Secrets.
- Minor refactoring to Pod component - moved all init container code to its own file.
- Adapted pod component to add vol and vol-mounts for satokensecret secret