### PR TITLE
rename getting started to installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Installation
 
 To get started with Grove, you can use the published Helm charts of Grove under the [GitHub packages section](https://github.com/orgs/NVIDIA/packages?repo_name=grove), and install Grove in your cluster.
 You can also try out Grove locally on your machine using a [kind](https://kind.sigs.k8s.io/) cluster, using the make targets we provide as a part of the repository.


### PR DESCRIPTION
Doc rename getting_started.md -> installation.md because we will add a separate quickstart guide.