### PR TITLE
Update validation webhooks

### DIFF
--- a/operator/internal/webhook/admission/pgs/validation/podgangset.go
+++ b/operator/internal/webhook/admission/pgs/validation/podgangset.go
@@ -477,7 +477,6 @@ func (v *pgsValidator) validateUpdate(oldPgs *grovecorev1alpha1.PodGangSet) erro
 	allErrs := field.ErrorList{}
 	fldPath := field.NewPath("spec")
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(v.pgs.Spec.ReplicaSpreadConstraints, oldPgs.Spec.ReplicaSpreadConstraints, fldPath.Child("replicaSpreadConstraints"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(v.pgs.Spec.Template.PriorityClassName, oldPgs.Spec.Template.PriorityClassName, fldPath.Child("priorityClassName"))...)
 	allErrs = append(allErrs, validatePodGangSetSpecUpdate(&v.pgs.Spec, &oldPgs.Spec, fldPath)...)
 	return allErrs.ToAggregate()
 }
@@ -491,9 +490,10 @@ func validatePodGangSetSpecUpdate(newSpec, oldSpec *grovecorev1alpha1.PodGangSet
 func validatePodGangTemplateSpecUpdate(newSpec, oldSpec *grovecorev1alpha1.PodGangSetTemplateSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, validatePodCliqueUpdate(newSpec.Cliques, oldSpec.Cliques, fldPath.Child("cliques"))...)
+	allErrs = append(allErrs, validatePodCliqueUpdate(newSpec.Cliques, oldSpec.Cliques, newSpec.StartupType, fldPath.Child("cliques"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.StartupType, oldSpec.StartupType, fldPath.Child("cliqueStartupType"))...)
 	allErrs = append(allErrs, validatePodGangSchedulingPolicyConfigUpdate(newSpec.SchedulingPolicyConfig, newSpec.SchedulingPolicyConfig, fldPath.Child("schedulingPolicyConfig"))...)
+	allErrs = append(allErrs, validatePodCliqueScalingGroupConfigsUpdate(newSpec.PodCliqueScalingGroupConfigs, oldSpec.PodCliqueScalingGroupConfigs, fldPath.Child("podCliqueScalingGroups"))...)
 
 	return allErrs
 }
@@ -504,7 +504,44 @@ func validatePodGangSchedulingPolicyConfigUpdate(newConfig, oldConfig *grovecore
 	return allErrs
 }
 
-func validatePodCliqueUpdate(newCliques, oldCliques []*grovecorev1alpha1.PodCliqueTemplateSpec, fldPath *field.Path) field.ErrorList {
+// validatePodCliqueScalingGroupConfigsUpdate validates immutable fields in PodCliqueScalingGroupConfigs
+func validatePodCliqueScalingGroupConfigsUpdate(newConfigs, oldConfigs []grovecorev1alpha1.PodCliqueScalingGroupConfig, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Validate that scaling group composition hasn't changed
+	if len(newConfigs) != len(oldConfigs) {
+		allErrs = append(allErrs, field.Forbidden(fldPath, "not allowed to add or remove PodCliqueScalingGroupConfigs"))
+		return allErrs
+	}
+
+	// Create a map of old configs by name for efficient lookup
+	oldConfigMap := lo.SliceToMap(oldConfigs, func(config grovecorev1alpha1.PodCliqueScalingGroupConfig) (string, grovecorev1alpha1.PodCliqueScalingGroupConfig) {
+		return config.Name, config
+	})
+
+	// Validate each new config against its corresponding old config by name
+	for _, newConfig := range newConfigs {
+		oldConfig, exists := oldConfigMap[newConfig.Name]
+		if !exists {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("name"), fmt.Sprintf("not allowed to change scaling group composition, new scaling group name '%s' is not allowed", newConfig.Name)))
+			continue
+		}
+
+		// Validate immutable fields
+		configFldPath := fldPath
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig.CliqueNames, oldConfig.CliqueNames, configFldPath.Child("cliqueNames"))...)
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig.MinAvailable, oldConfig.MinAvailable, configFldPath.Child("minAvailable"))...)
+	}
+
+	return allErrs
+}
+
+// requiresOrderValidation checks if the StartupType requires clique order validation
+func requiresOrderValidation(startupType *grovecorev1alpha1.CliqueStartupType) bool {
+	return startupType != nil && (*startupType == grovecorev1alpha1.CliqueStartupTypeInOrder || *startupType == grovecorev1alpha1.CliqueStartupTypeExplicit)
+}
+
+func validatePodCliqueUpdate(newCliques, oldCliques []*grovecorev1alpha1.PodCliqueTemplateSpec, startupType *grovecorev1alpha1.CliqueStartupType, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(newCliques) != len(oldCliques) {
@@ -512,18 +549,37 @@ func validatePodCliqueUpdate(newCliques, oldCliques []*grovecorev1alpha1.PodCliq
 	}
 
 	// Create a map of old cliques by name for efficient lookup
-	oldCliqueMap := lo.SliceToMap(oldCliques, func(clique *grovecorev1alpha1.PodCliqueTemplateSpec) (string, *grovecorev1alpha1.PodCliqueTemplateSpec) {
-		return clique.Name, clique
+	// this allows to check the type and order without deal with non exits indexes in a slice of the old cliques
+	// if the length the old cliques and new cliques is different is an error but we dont return it immediately so farther validation can be done
+	// therefore we should not assume the length of the oldCliques slice is the same as the newCliques slice
+	oldCliqueIndexMap := make(map[string]lo.Tuple2[int, *grovecorev1alpha1.PodCliqueTemplateSpec], len(oldCliques))
+	lo.ForEach(oldCliques, func(clique *grovecorev1alpha1.PodCliqueTemplateSpec, i int) {
+		oldCliqueIndexMap[clique.Name] = lo.Tuple2[int, *grovecorev1alpha1.PodCliqueTemplateSpec]{A: i, B: clique}
 	})
-
-	// Validate each new clique against its corresponding old clique by name
-	for _, newClique := range newCliques {
-		oldClique, exists := oldCliqueMap[newClique.Name]
+	// Validate each new clique against its corresponding old clique
+	for newCliqueIndex, newClique := range newCliques {
+		oldIndexCliqueTuple, exists := oldCliqueIndexMap[newClique.Name]
 		if !exists {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("name"), fmt.Sprintf("not allowed to change clique composition, new clique name '%s' is not allowed", newClique.Name)))
 			continue
 		}
-		allErrs = append(allErrs, validatePodSpecUpdate(&newClique.Spec.PodSpec, &oldClique.Spec.PodSpec, fldPath.Child("spec", "podSpec"))...)
+
+		// Validate clique order for StartupType InOrder and Explicit
+		// If the StartupType is InOrder or Explicit, the order of cliques cannot change
+		// the index new clique is compared with the index of the old clique
+		if requiresOrderValidation(startupType) && newCliqueIndex != oldIndexCliqueTuple.A {
+			allErrs = append(allErrs, field.Invalid(fldPath, newClique.Name,
+				fmt.Sprintf("clique order cannot be changed when StartupType is InOrder or Explicit. Expected '%s' at position %d, got '%s'",
+					oldIndexCliqueTuple.B.Name, newCliqueIndex, newClique.Name)))
+		}
+
+		// Validate immutable PodClique fields
+		cliqueFldPath := fldPath.Child("spec")
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newClique.Spec.RoleName, oldIndexCliqueTuple.B.Spec.RoleName, cliqueFldPath.Child("roleName"))...)
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newClique.Spec.MinAvailable, oldIndexCliqueTuple.B.Spec.MinAvailable, cliqueFldPath.Child("minAvailable"))...)
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newClique.Spec.StartsAfter, oldIndexCliqueTuple.B.Spec.StartsAfter, cliqueFldPath.Child("startsAfter"))...)
+
+		allErrs = append(allErrs, validatePodSpecUpdate(&newClique.Spec.PodSpec, &oldIndexCliqueTuple.B.Spec.PodSpec, fldPath.Child("spec", "podSpec"))...)
 	}
 
 	return allErrs

--- a/operator/internal/webhook/admission/pgs/validation/podgangset.go
+++ b/operator/internal/webhook/admission/pgs/validation/podgangset.go
@@ -556,6 +556,7 @@ func validatePodCliqueUpdate(newCliques, oldCliques []*grovecorev1alpha1.PodCliq
 	lo.ForEach(oldCliques, func(clique *grovecorev1alpha1.PodCliqueTemplateSpec, i int) {
 		oldCliqueIndexMap[clique.Name] = lo.Tuple2[int, *grovecorev1alpha1.PodCliqueTemplateSpec]{A: i, B: clique}
 	})
+	orderIsEnforced := requiresOrderValidation(startupType)
 	// Validate each new clique against its corresponding old clique
 	for newCliqueIndex, newClique := range newCliques {
 		oldIndexCliqueTuple, exists := oldCliqueIndexMap[newClique.Name]
@@ -567,7 +568,7 @@ func validatePodCliqueUpdate(newCliques, oldCliques []*grovecorev1alpha1.PodCliq
 		// Validate clique order for StartupType InOrder and Explicit
 		// If the StartupType is InOrder or Explicit, the order of cliques cannot change
 		// the index new clique is compared with the index of the old clique
-		if requiresOrderValidation(startupType) && newCliqueIndex != oldIndexCliqueTuple.A {
+		if orderIsEnforced && newCliqueIndex != oldIndexCliqueTuple.A {
 			allErrs = append(allErrs, field.Invalid(fldPath, newClique.Name,
 				fmt.Sprintf("clique order cannot be changed when StartupType is InOrder or Explicit. Expected '%s' at position %d, got '%s'",
 					oldIndexCliqueTuple.B.Name, newCliqueIndex, newClique.Name)))

--- a/operator/internal/webhook/admission/pgs/validation/podgangset_test.go
+++ b/operator/internal/webhook/admission/pgs/validation/podgangset_test.go
@@ -23,70 +23,38 @@ import (
 	"time"
 
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+	testutils "github.com/NVIDIA/grove/operator/test/utils"
 
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 )
 
-// Helper function to create a dummy valid PodGangSet
-// with a minimal configuration
-// This is used to test the validation logic without needing a full setup.
+// Temporary helper function for remaining tests - to be refactored
 func createDummyPodGangSet(name string) *grovecorev1alpha1.PodGangSet {
-	return &grovecorev1alpha1.PodGangSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "default",
-		},
-		Spec: grovecorev1alpha1.PodGangSetSpec{
-			Replicas: 1,
-			Template: grovecorev1alpha1.PodGangSetTemplateSpec{
-				TerminationDelay: &metav1.Duration{Duration: 30 * time.Second},
-				StartupType:      ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder),
-				Cliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
-					{
-						Name:        "test",
-						Labels:      nil,
-						Annotations: nil,
-						Spec: grovecorev1alpha1.PodCliqueSpec{
-							Replicas:     1,
-							RoleName:     "dummy-role",
-							MinAvailable: ptr.To[int32](1),
-						},
-					},
-				},
-			},
-		},
-	}
+	return testutils.NewPodGangSetBuilder(name, "default").
+		WithReplicas(1).
+		WithTerminationDelay(30 * time.Second).
+		WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder)).
+		WithPodCliqueTemplateSpec(
+			testutils.NewPodCliqueTemplateSpecBuilder("test").
+				WithReplicas(1).
+				WithRoleName("dummy-role").
+				WithMinAvailable(1).
+				Build()).
+		Build()
 }
 
-// createDummyPodCliqueTemplate Helper function to create a valid PodCliqueTemplateSpec with predefined values
-// This is used to test the validation logic without needing a full setup.
-// It creates a PodCliqueTemplateSpec with a single container and minimal configuration.
 func createDummyPodCliqueTemplate(name string) *grovecorev1alpha1.PodCliqueTemplateSpec {
-	return &grovecorev1alpha1.PodCliqueTemplateSpec{
-		Name: name,
-		Spec: grovecorev1alpha1.PodCliqueSpec{
-			Replicas:     1,
-			MinAvailable: ptr.To(int32(1)),
-			PodSpec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "test-container",
-						Image: "test:latest",
-					},
-				},
-			},
-			RoleName: fmt.Sprintf("dummy-%s-role", name),
-		},
-	}
+	return testutils.NewPodCliqueTemplateSpecBuilder(name).
+		WithReplicas(1).
+		WithRoleName(fmt.Sprintf("dummy-%s-role", name)).
+		WithMinAvailable(1).
+		Build()
 }
 
-// Helper function to create a PodCliqueScalingGroupConfig
 func createScalingGroupConfig(name string, cliqueNames []string) grovecorev1alpha1.PodCliqueScalingGroupConfig {
 	return grovecorev1alpha1.PodCliqueScalingGroupConfig{
 		Name:        name,
@@ -94,169 +62,96 @@ func createScalingGroupConfig(name string, cliqueNames []string) grovecorev1alph
 	}
 }
 
-func TestPodCliqueTemplateNameValidation(t *testing.T) {
+func TestResourceNamingValidation(t *testing.T) {
 	testCases := []struct {
-		description     string
-		pgsName         string
-		cliqueNames     []string
-		expectError     bool
-		expectedErrMsg  string
-		expectedErrPath string
+		description      string
+		pgsName          string
+		cliqueNames      []string
+		scalingGroups    []grovecorev1alpha1.PodCliqueScalingGroupConfig
+		expectError      bool
+		expectedErrMsg   string
+		expectedErrCount int
 	}{
 		{
-			description: "Valid PodClique template names",
+			description: "Valid resource names",
 			pgsName:     "inference",
 			cliqueNames: []string{"prefill", "decode"},
-			expectError: false,
-		},
-		{
-			description:     "PodClique template name that exceeds character limit",
-			pgsName:         "verylongpodgangsetnamethatisverylong",            // 34 chars
-			cliqueNames:     []string{"verylongpodcliquenamethatexceedslimit"}, // 37 chars, total 34+37=71 > 45
-			expectError:     true,
-			expectedErrMsg:  "combined resource name length",
-			expectedErrPath: "spec.template.cliques.name",
-		},
-		{
-			description:     "Empty PodClique template name",
-			pgsName:         "inference",
-			cliqueNames:     []string{""},
-			expectError:     true,
-			expectedErrMsg:  "field cannot be empty",
-			expectedErrPath: "spec.template.cliques.name",
-		},
-		{
-			description:     "PodClique template name with invalid characters",
-			pgsName:         "inference",
-			cliqueNames:     []string{"prefill_worker"},
-			expectError:     true,
-			expectedErrMsg:  "invalid PodCliqueTemplateSpec name",
-			expectedErrPath: "spec.template.cliques.name",
-		},
-		{
-			description: "Multiple PodClique templates with valid names",
-			pgsName:     "inference",
-			cliqueNames: []string{"prefill", "decode", "embed"},
-			expectError: false,
-		},
-		{
-			description:     "Multiple PodClique templates with one invalid name",
-			pgsName:         "inference",
-			cliqueNames:     []string{"prefill", "verylongpodcliquenamethatexceedslimit"},
-			expectError:     true,
-			expectedErrMsg:  "combined resource name length",
-			expectedErrPath: "spec.template.cliques.name",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			pgs := createDummyPodGangSet(tc.pgsName)
-
-			// Add PodClique templates
-			for _, cliqueName := range tc.cliqueNames {
-				pgs.Spec.Template.Cliques = append(pgs.Spec.Template.Cliques, createDummyPodCliqueTemplate(cliqueName))
-			}
-
-			validator := newPGSValidator(pgs, admissionv1.Create)
-			warnings, err := validator.validate()
-
-			if !tc.expectError {
-				assert.NoError(t, err, "Expected no validation error for test case: %s", tc.description)
-			} else {
-				assert.Error(t, err, "Expected validation error for test case: %s", tc.description)
-				assert.Contains(t, err.Error(), tc.expectedErrMsg, "Error message should contain expected text")
-				// Check if this is an aggregate error with field errors
-				var aggErr utilerrors.Aggregate
-				if errors.As(err, &aggErr) && len(aggErr.Errors()) > 0 {
-					var fieldErr *field.Error
-					if errors.As(aggErr.Errors()[0], &fieldErr) {
-						assert.Contains(t, fieldErr.Field, tc.expectedErrPath, "Error field path should match expected")
-					}
-				}
-			}
-
-			// Warnings should be empty for these test cases
-			assert.Empty(t, warnings, "No warnings expected for these test cases")
-		})
-	}
-}
-
-func TestScalingGroupPodCliqueNameValidation(t *testing.T) {
-	testCases := []struct {
-		description     string
-		pgsName         string
-		scalingGroups   []grovecorev1alpha1.PodCliqueScalingGroupConfig
-		cliqueTemplates []string
-		expectError     bool
-		expectedErrMsg  string
-		expectedErrPath string
-	}{
-		{
-			description: "Valid scaling group with valid PodClique names",
-			pgsName:     "inference",
 			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
 				createScalingGroupConfig("workers", []string{"prefill", "decode"}),
 			},
-			cliqueTemplates: []string{"prefill", "decode"},
-			expectError:     false,
+			expectError: false,
 		},
 		{
-			description: "Scaling group with PodClique names exceeding character limit",
-			pgsName:     "verylongpodgangsetname",
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				createScalingGroupConfig("verylongscalinggroup", []string{"verylongpodcliquename"}),
-			},
-			cliqueTemplates: []string{"verylongpodcliquename"},
-			expectError:     true,
-			expectedErrMsg:  "combined resource name length",
-			expectedErrPath: "spec.template.podCliqueScalingGroups.cliqueNames.name",
+			description:      "PodClique template name exceeds character limit",
+			pgsName:          "verylongpodgangsetnamethatisverylong",
+			cliqueNames:      []string{"verylongpodcliquenamethatexceedslimit"},
+			expectError:      true,
+			expectedErrMsg:   "combined resource name length",
+			expectedErrCount: 2,
 		},
 		{
-			description: "Multiple scaling groups with valid names",
-			pgsName:     "inference",
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				createScalingGroupConfig("workers", []string{"prefill"}),
-				createScalingGroupConfig("embedders", []string{"embed"}),
-			},
-			cliqueTemplates: []string{"prefill", "embed"},
-			expectError:     false,
+			description:    "Empty PodClique template name",
+			pgsName:        "inference",
+			cliqueNames:    []string{""},
+			expectError:    true,
+			expectedErrMsg: "field cannot be empty",
 		},
 		{
-			description: "Scaling group with mixed valid/invalid PodClique names",
-			pgsName:     "inference",
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				createScalingGroupConfig("workers", []string{"prefill", "verylongpodcliquenamethatexceedslimit"}),
-			},
-			cliqueTemplates: []string{"prefill", "verylongpodcliquenamethatexceedslimit"},
-			expectError:     true,
-			expectedErrMsg:  "combined resource name length",
-			expectedErrPath: "spec.template.podCliqueScalingGroups.cliqueNames.name",
+			description:    "PodClique template name with invalid characters",
+			pgsName:        "inference",
+			cliqueNames:    []string{"prefill_worker"},
+			expectError:    true,
+			expectedErrMsg: "invalid PodCliqueTemplateSpec name",
 		},
 		{
-			description: "Scaling group referencing non-existent PodClique",
-			pgsName:     "inference",
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				createScalingGroupConfig("workers", []string{"nonexistent"}),
-			},
-			cliqueTemplates: []string{"prefill"},
-			expectError:     true,
-			expectedErrMsg:  "unidentified PodClique names found",
-			expectedErrPath: "spec.template.podCliqueScalingGroups.cliqueNames",
+			description:      "Scaling group with long names",
+			pgsName:          "verylongpodgangsetname",
+			cliqueNames:      []string{"verylongpodcliquename"},
+			scalingGroups:    []grovecorev1alpha1.PodCliqueScalingGroupConfig{createScalingGroupConfig("verylongscalinggroup", []string{"verylongpodcliquename"})},
+			expectError:      true,
+			expectedErrMsg:   "combined resource name length",
+			expectedErrCount: 3,
+		},
+		{
+			description:    "Scaling group referencing non-existent PodClique",
+			pgsName:        "inference",
+			cliqueNames:    []string{"prefill"},
+			scalingGroups:  []grovecorev1alpha1.PodCliqueScalingGroupConfig{createScalingGroupConfig("workers", []string{"nonexistent"})},
+			expectError:    true,
+			expectedErrMsg: "unidentified PodClique names found",
+		},
+		{
+			description:   "Maximum valid character usage",
+			pgsName:       "pgs",
+			cliqueNames:   []string{"cliquename20charssss"},
+			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{createScalingGroupConfig("sg", []string{"cliquename20charssss"})},
+			expectError:   false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			pgs := createDummyPodGangSet(tc.pgsName)
+			pgsBuilder := testutils.NewPodGangSetBuilder(tc.pgsName, "default").
+				WithReplicas(1).
+				WithTerminationDelay(30 * time.Second).
+				WithCliqueStartupType(ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder))
 
 			// Add PodClique templates
-			for _, cliqueName := range tc.cliqueTemplates {
-				pgs.Spec.Template.Cliques = append(pgs.Spec.Template.Cliques, createDummyPodCliqueTemplate(cliqueName))
+			for _, cliqueName := range tc.cliqueNames {
+				clique := testutils.NewPodCliqueTemplateSpecBuilder(cliqueName).
+					WithReplicas(1).
+					WithRoleName(fmt.Sprintf("dummy-%s-role", cliqueName)).
+					WithMinAvailable(1).
+					Build()
+				pgsBuilder = pgsBuilder.WithPodCliqueTemplateSpec(clique)
 			}
 
 			// Add scaling groups
-			pgs.Spec.Template.PodCliqueScalingGroupConfigs = tc.scalingGroups
+			for _, config := range tc.scalingGroups {
+				pgsBuilder = pgsBuilder.WithPodCliqueScalingGroupConfig(config)
+			}
+
+			pgs := pgsBuilder.Build()
 
 			validator := newPGSValidator(pgs, admissionv1.Create)
 			warnings, err := validator.validate()
@@ -264,243 +159,17 @@ func TestScalingGroupPodCliqueNameValidation(t *testing.T) {
 			if tc.expectError {
 				assert.Error(t, err, "Expected validation error for test case: %s", tc.description)
 				assert.Contains(t, err.Error(), tc.expectedErrMsg, "Error message should contain expected text")
-			} else {
-				assert.NoError(t, err, "Expected no validation error for test case: %s", tc.description)
-			}
-
-			// Warnings should be empty for these test cases
-			assert.Empty(t, warnings, "No warnings expected for these test cases")
-		})
-	}
-}
-
-func TestPodGangSetIntegrationValidation(t *testing.T) {
-	testCases := []struct {
-		description      string
-		pgsName          string
-		cliqueTemplates  []string
-		scalingGroups    []grovecorev1alpha1.PodCliqueScalingGroupConfig
-		expectError      bool
-		expectedErrCount int
-		expectedErrMsgs  []string
-	}{
-		{
-			description:     "Valid PodGangSet with templates and scaling groups",
-			pgsName:         "inference",
-			cliqueTemplates: []string{"prefill", "decode", "embed"},
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				createScalingGroupConfig("workers", []string{"prefill", "decode"}),
-			},
-			expectError: false,
-		},
-		{
-			description:     "PodGangSet with invalid template and scaling group names",
-			pgsName:         "verylongpodgangsetname",
-			cliqueTemplates: []string{"verylongpodcliquename"},
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				createScalingGroupConfig("verylongscalinggroup", []string{"verylongpodcliquename"}),
-			},
-			expectError:      true,
-			expectedErrCount: 3, // Multiple field paths get validation errors (name, scaling group name, metadata name)
-			expectedErrMsgs:  []string{"combined resource name length"},
-		},
-		{
-			description:     "PodGangSet with maximum valid character usage",
-			pgsName:         "pgs",                            // 3 chars
-			cliqueTemplates: []string{"cliquename20charssss"}, // 20 chars total (3+20=23, well under 45)
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				createScalingGroupConfig("sg", []string{"cliquename20charssss"}), // 3+2+20=25, under 45
-			},
-			expectError: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			pgs := createDummyPodGangSet(tc.pgsName)
-
-			// Add PodClique templates
-			for _, cliqueName := range tc.cliqueTemplates {
-				pgs.Spec.Template.Cliques = append(pgs.Spec.Template.Cliques, createDummyPodCliqueTemplate(cliqueName))
-			}
-
-			// Add scaling groups
-			pgs.Spec.Template.PodCliqueScalingGroupConfigs = tc.scalingGroups
-
-			validator := newPGSValidator(pgs, admissionv1.Create)
-			warnings, err := validator.validate()
-
-			if !tc.expectError {
-				assert.NoError(t, err, "Expected no validation error for test case: %s", tc.description)
-			} else {
-				assert.Error(t, err, "Expected validation error for test case: %s", tc.description)
-				// Check error count if specified
 				if tc.expectedErrCount > 0 {
 					var aggErr utilerrors.Aggregate
 					if errors.As(err, &aggErr) {
 						assert.Len(t, aggErr.Errors(), tc.expectedErrCount, "Expected specific number of validation errors")
 					}
 				}
-
-				// Check error messages if specified
-				for _, expectedMsg := range tc.expectedErrMsgs {
-					assert.Contains(t, err.Error(), expectedMsg, "Error should contain expected message")
-				}
-			}
-
-			// Warnings should be empty for these test cases
-			assert.Empty(t, warnings, "No warnings expected for these test cases")
-		})
-	}
-}
-
-func TestErrorFieldPaths(t *testing.T) {
-	testCases := []struct {
-		description       string
-		pgsName           string
-		cliqueNames       []string
-		scalingGroups     []grovecorev1alpha1.PodCliqueScalingGroupConfig
-		expectedFieldErrs []string
-	}{
-		{
-			description: "Template name validation error paths",
-			pgsName:     "verylongpodgangsetnamethatisverylong",            // 34 chars
-			cliqueNames: []string{"verylongpodcliquenamethatexceedslimit"}, // 37 chars, total > 45
-			expectedFieldErrs: []string{
-				"spec.template.cliques.name",
-				"metadata.name",
-			},
-		},
-		{
-			description: "Scaling group name validation error paths",
-			pgsName:     "verylongpodgangsetname",
-			cliqueNames: []string{"validname"},
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				createScalingGroupConfig("verylongscalinggroup", []string{"verylongpodcliquename"}),
-			},
-			expectedFieldErrs: []string{
-				"spec.template.podCliqueScalingGroups.cliqueNames.name",
-				"spec.template.podCliqueScalingGroups.name",
-				"metadata.name",
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			pgs := createDummyPodGangSet(tc.pgsName)
-
-			// Add PodClique templates
-			for _, cliqueName := range tc.cliqueNames {
-				pgs.Spec.Template.Cliques = append(pgs.Spec.Template.Cliques, createDummyPodCliqueTemplate(cliqueName))
-			}
-
-			// Add scaling groups
-			pgs.Spec.Template.PodCliqueScalingGroupConfigs = tc.scalingGroups
-
-			validator := newPGSValidator(pgs, admissionv1.Create)
-			_, err := validator.validate()
-
-			assert.Error(t, err, "Expected validation error")
-
-			var actualFieldPaths []string
-			if aggErr, ok := err.(utilerrors.Aggregate); ok {
-				for _, e := range aggErr.Errors() {
-					if fieldErr, ok := e.(*field.Error); ok {
-						actualFieldPaths = append(actualFieldPaths, fieldErr.Field)
-					}
-				}
-			}
-
-			// Check that all expected field paths are present
-			for _, expectedPath := range tc.expectedFieldErrs {
-				found := false
-				for _, actualPath := range actualFieldPaths {
-					if actualPath == expectedPath {
-						found = true
-						break
-					}
-				}
-				assert.True(t, found, "Expected field path %s not found in actual errors: %v", expectedPath, actualFieldPaths)
-			}
-		})
-	}
-}
-
-func TestValidatePodNameConstraints(t *testing.T) {
-	testCases := []struct {
-		description string
-		pgsName     string
-		pcsgName    string
-		pclqName    string
-		expectError bool
-	}{
-		{
-			description: "Valid PCSG component names",
-			pgsName:     "inference",
-			pcsgName:    "workers",
-			pclqName:    "prefill",
-			expectError: false,
-		},
-		{
-			description: "Valid non-PCSG component names",
-			pgsName:     "inference",
-			pcsgName:    "",
-			pclqName:    "prefill",
-			expectError: false,
-		},
-		{
-			description: "Resource names exceed 45 characters",
-			pgsName:     "verylongpgsname",
-			pcsgName:    "verylongpcsgname",
-			pclqName:    "verylongpclqname",
-			expectError: true,
-		},
-		{
-			description: "Non-PCSG resource names exceed 45 characters",
-			pgsName:     "verylongpodgangsetnamethatisverylong",
-			pcsgName:    "",
-			pclqName:    "verylongpodcliquename",
-			expectError: true,
-		},
-		{
-			description: "Maximum valid character usage for PCSG",
-			pgsName:     "pgs",
-			pcsgName:    "sg",
-			pclqName:    "cliquename20charssss",
-			expectError: false,
-		},
-		{
-			description: "Maximum valid character usage for non-PCSG",
-			pgsName:     "pgsnametwentychars123",
-			pcsgName:    "",
-			pclqName:    "cliquenametwentyfourchar",
-			expectError: false,
-		},
-		{
-			description: "Edge case - exactly 45 characters",
-			pgsName:     "twentycharspgsnames12",
-			pcsgName:    "",
-			pclqName:    "twentyfourcharspclqname1",
-			expectError: false,
-		},
-		{
-			description: "Edge case - 46 characters (should fail)",
-			pgsName:     "twentyonecharspgsnames",
-			pcsgName:    "",
-			pclqName:    "twentyfivecharspclqname12",
-			expectError: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			err := validatePodNameConstraints(tc.pgsName, tc.pcsgName, tc.pclqName)
-			if tc.expectError {
-				assert.Error(t, err, "Expected error for component names: pgs=%s, pcsg=%s, pclq=%s", tc.pgsName, tc.pcsgName, tc.pclqName)
 			} else {
-				assert.NoError(t, err, "Expected no error for component names: pgs=%s, pcsg=%s, pclq=%s", tc.pgsName, tc.pcsgName, tc.pclqName)
+				assert.NoError(t, err, "Expected no validation error for test case: %s", tc.description)
 			}
+
+			assert.Empty(t, warnings, "No warnings expected for these test cases")
 		})
 	}
 }
@@ -544,36 +213,6 @@ func TestPodCliqueScalingGroupConfigValidation(t *testing.T) {
 			expectedErrMsg:  "must be greater than 0",
 		},
 		{
-			description: "Invalid Replicas (zero value)",
-			pgsName:     "inference",
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				{
-					Name:         "workers",
-					CliqueNames:  []string{"prefill"},
-					Replicas:     ptr.To(int32(0)),
-					MinAvailable: ptr.To(int32(1)),
-				},
-			},
-			cliqueTemplates: []string{"prefill"},
-			expectError:     true,
-			expectedErrMsg:  "must be greater than 0",
-		},
-		{
-			description: "Invalid MinAvailable (negative value)",
-			pgsName:     "inference",
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				{
-					Name:         "workers",
-					CliqueNames:  []string{"prefill"},
-					Replicas:     ptr.To(int32(4)),
-					MinAvailable: ptr.To(int32(-1)),
-				},
-			},
-			cliqueTemplates: []string{"prefill"},
-			expectError:     true,
-			expectedErrMsg:  "must be greater than 0",
-		},
-		{
 			description: "Invalid MinAvailable (zero value)",
 			pgsName:     "inference",
 			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
@@ -604,20 +243,6 @@ func TestPodCliqueScalingGroupConfigValidation(t *testing.T) {
 			expectedErrMsg:  "minAvailable must not be greater than replicas",
 		},
 		{
-			description: "Valid MinAvailable = Replicas",
-			pgsName:     "inference",
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				{
-					Name:         "workers",
-					CliqueNames:  []string{"prefill"},
-					Replicas:     ptr.To(int32(4)),
-					MinAvailable: ptr.To(int32(4)),
-				},
-			},
-			cliqueTemplates: []string{"prefill"},
-			expectError:     false,
-		},
-		{
 			description: "Invalid ScaleConfig.MinReplicas < MinAvailable",
 			pgsName:     "inference",
 			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
@@ -637,56 +262,13 @@ func TestPodCliqueScalingGroupConfigValidation(t *testing.T) {
 			expectedErrMsg:  "scaleConfig.minReplicas must be greater than or equal to minAvailable",
 		},
 		{
-			description: "Valid ScaleConfig.MinReplicas >= MinAvailable",
-			pgsName:     "inference",
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				{
-					Name:         "workers",
-					CliqueNames:  []string{"prefill"},
-					Replicas:     ptr.To(int32(4)),
-					MinAvailable: ptr.To(int32(2)),
-					ScaleConfig: &grovecorev1alpha1.AutoScalingConfig{
-						MinReplicas: ptr.To(int32(3)),
-						MaxReplicas: 10,
-					},
-				},
-			},
-			cliqueTemplates: []string{"prefill"},
-			expectError:     false,
-		},
-		{
-			description: "Valid when only Replicas is specified",
+			description: "Valid with partial configuration",
 			pgsName:     "inference",
 			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
 				{
 					Name:        "workers",
 					CliqueNames: []string{"prefill"},
 					Replicas:    ptr.To(int32(4)),
-				},
-			},
-			cliqueTemplates: []string{"prefill"},
-			expectError:     false,
-		},
-		{
-			description: "Valid when only MinAvailable is specified",
-			pgsName:     "inference",
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				{
-					Name:         "workers",
-					CliqueNames:  []string{"prefill"},
-					MinAvailable: ptr.To(int32(2)),
-				},
-			},
-			cliqueTemplates: []string{"prefill"},
-			expectError:     false,
-		},
-		{
-			description: "Valid when neither Replicas nor MinAvailable is specified",
-			pgsName:     "inference",
-			scalingGroups: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
-				{
-					Name:        "workers",
-					CliqueNames: []string{"prefill"},
 				},
 			},
 			cliqueTemplates: []string{"prefill"},
@@ -716,22 +298,23 @@ func TestPodCliqueScalingGroupConfigValidation(t *testing.T) {
 				assert.NoError(t, err, "Expected no validation error for test case: %s", tc.description)
 			}
 
-			// Warnings should be empty for these test cases
 			assert.Empty(t, warnings, "No warnings expected for these test cases")
 		})
 	}
 }
 
-func TestValidatePodCliqueUpdate(t *testing.T) {
+func TestPodCliqueUpdateValidation(t *testing.T) {
 	testCases := []struct {
 		name           string
+		startupType    *grovecorev1alpha1.CliqueStartupType
 		oldCliques     []*grovecorev1alpha1.PodCliqueTemplateSpec
 		newCliques     []*grovecorev1alpha1.PodCliqueTemplateSpec
 		expectError    bool
 		expectedErrMsg string
 	}{
 		{
-			name: "Valid: same cliques in different order",
+			name:        "Valid: same cliques in different order with AnyOrder",
+			startupType: ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder),
 			oldCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
 				createDummyPodCliqueTemplate("prefill"),
 				createDummyPodCliqueTemplate("decode"),
@@ -743,7 +326,62 @@ func TestValidatePodCliqueUpdate(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "Valid: same cliques in same order",
+			name:        "Invalid: adding new clique",
+			startupType: ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder),
+			oldCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				createDummyPodCliqueTemplate("prefill"),
+			},
+			newCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				createDummyPodCliqueTemplate("prefill"),
+				createDummyPodCliqueTemplate("decode"),
+			},
+			expectError:    true,
+			expectedErrMsg: "not allowed to change clique composition",
+		},
+		{
+			name:        "Invalid: removing clique",
+			startupType: ptr.To(grovecorev1alpha1.CliqueStartupTypeAnyOrder),
+			oldCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				createDummyPodCliqueTemplate("prefill"),
+				createDummyPodCliqueTemplate("decode"),
+			},
+			newCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				createDummyPodCliqueTemplate("prefill"),
+			},
+			expectError:    true,
+			expectedErrMsg: "not allowed to change clique composition",
+		},
+		{
+			name:        "Invalid: InOrder doesn't allow order change",
+			startupType: ptr.To(grovecorev1alpha1.CliqueStartupTypeInOrder),
+			oldCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				createDummyPodCliqueTemplate("prefill"),
+				createDummyPodCliqueTemplate("decode"),
+			},
+			newCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				createDummyPodCliqueTemplate("decode"),
+				createDummyPodCliqueTemplate("prefill"),
+			},
+			expectError:    true,
+			expectedErrMsg: "clique order cannot be changed when StartupType is InOrder or Explicit",
+		},
+		{
+			name:        "Invalid: Explicit doesn't allow order change",
+			startupType: ptr.To(grovecorev1alpha1.CliqueStartupTypeExplicit),
+			oldCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				createDummyPodCliqueTemplate("prefill"),
+				createDummyPodCliqueTemplate("decode"),
+			},
+			newCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
+				createDummyPodCliqueTemplate("decode"),
+				createDummyPodCliqueTemplate("prefill"),
+			},
+			expectError:    true,
+			expectedErrMsg: "clique order cannot be changed when StartupType is InOrder or Explicit",
+		},
+		{
+			name:        "Valid: InOrder allows same order",
+			startupType: ptr.To(grovecorev1alpha1.CliqueStartupTypeInOrder),
 			oldCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
 				createDummyPodCliqueTemplate("prefill"),
 				createDummyPodCliqueTemplate("decode"),
@@ -755,49 +393,22 @@ func TestValidatePodCliqueUpdate(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "Invalid: adding new clique",
-			oldCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
-				createDummyPodCliqueTemplate("prefill"),
-			},
-			newCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
-				createDummyPodCliqueTemplate("prefill"),
-				createDummyPodCliqueTemplate("decode"),
-			},
-			expectError:    true,
-			expectedErrMsg: "not allowed to change clique composition",
+			name:        "Edge case: empty arrays",
+			startupType: ptr.To(grovecorev1alpha1.CliqueStartupTypeInOrder),
+			oldCliques:  []*grovecorev1alpha1.PodCliqueTemplateSpec{},
+			newCliques:  []*grovecorev1alpha1.PodCliqueTemplateSpec{},
+			expectError: false,
 		},
 		{
-			name: "Invalid: removing clique",
+			name:        "Edge case: nil StartupType allows order change",
+			startupType: nil,
 			oldCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
-				createDummyPodCliqueTemplate("prefill"),
-				createDummyPodCliqueTemplate("decode"),
+				createDummyPodCliqueTemplate("a"),
+				createDummyPodCliqueTemplate("b"),
 			},
 			newCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
-				createDummyPodCliqueTemplate("prefill"),
-			},
-			expectError:    true,
-			expectedErrMsg: "not allowed to change clique composition",
-		},
-		{
-			name: "Invalid: new clique name not in old cliques",
-			oldCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
-				createDummyPodCliqueTemplate("prefill"),
-				createDummyPodCliqueTemplate("decode"),
-			},
-			newCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
-				createDummyPodCliqueTemplate("prefill"),
-				createDummyPodCliqueTemplate("embedding"),
-			},
-			expectError:    true,
-			expectedErrMsg: "not allowed to change clique composition, new clique name 'embedding' is not allowed",
-		},
-		{
-			name: "Valid: single clique unchanged",
-			oldCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
-				createDummyPodCliqueTemplate("worker"),
-			},
-			newCliques: []*grovecorev1alpha1.PodCliqueTemplateSpec{
-				createDummyPodCliqueTemplate("worker"),
+				createDummyPodCliqueTemplate("b"),
+				createDummyPodCliqueTemplate("a"),
 			},
 			expectError: false,
 		},
@@ -807,11 +418,304 @@ func TestValidatePodCliqueUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fldPath := field.NewPath("spec").Child("template").Child("cliques")
 
-			validationErrors := validatePodCliqueUpdate(tc.newCliques, tc.oldCliques, fldPath)
+			validationErrors := validatePodCliqueUpdate(tc.newCliques, tc.oldCliques, tc.startupType, fldPath)
 
 			if tc.expectError {
 				assert.NotEmpty(t, validationErrors, "Expected validation errors for test case: %s", tc.name)
-				// Convert field errors to string to check error message
+				var errorMessages []string
+				for _, err := range validationErrors {
+					errorMessages = append(errorMessages, err.Error())
+				}
+				errorString := fmt.Sprintf("%v", errorMessages)
+				assert.Contains(t, errorString, tc.expectedErrMsg, "Error message should contain expected text")
+			} else {
+				assert.Empty(t, validationErrors, "Expected no validation errors for test case: %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestImmutableFieldsValidation(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setupOldPGS    func() *grovecorev1alpha1.PodGangSet
+		setupNewPGS    func() *grovecorev1alpha1.PodGangSet
+		expectError    bool
+		expectedErrMsg string
+	}{
+		{
+			name: "Valid: PriorityClassName can be updated",
+			setupOldPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.PriorityClassName = "old-priority"
+				return pgs
+			},
+			setupNewPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.PriorityClassName = "new-priority"
+				return pgs
+			},
+			expectError: false,
+		},
+		{
+			name: "Invalid: RoleName is immutable",
+			setupOldPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.Cliques[0].Spec.RoleName = "old-role"
+				return pgs
+			},
+			setupNewPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.Cliques[0].Spec.RoleName = "new-role"
+				return pgs
+			},
+			expectError:    true,
+			expectedErrMsg: "field is immutable",
+		},
+		{
+			name: "Invalid: MinAvailable is immutable",
+			setupOldPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.Cliques[0].Spec.MinAvailable = ptr.To(int32(1))
+				return pgs
+			},
+			setupNewPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.Cliques[0].Spec.MinAvailable = ptr.To(int32(2))
+				return pgs
+			},
+			expectError:    true,
+			expectedErrMsg: "field is immutable",
+		},
+		{
+			name: "Invalid: StartsAfter is immutable",
+			setupOldPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.StartupType = ptr.To(grovecorev1alpha1.CliqueStartupTypeExplicit)
+				pgs.Spec.Template.Cliques = append(pgs.Spec.Template.Cliques, createDummyPodCliqueTemplate("clique2"))
+				pgs.Spec.Template.Cliques[0].Spec.StartsAfter = []string{}
+				pgs.Spec.Template.Cliques[1].Spec.StartsAfter = []string{"test"}
+				return pgs
+			},
+			setupNewPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.StartupType = ptr.To(grovecorev1alpha1.CliqueStartupTypeExplicit)
+				pgs.Spec.Template.Cliques = append(pgs.Spec.Template.Cliques, createDummyPodCliqueTemplate("clique2"))
+				pgs.Spec.Template.Cliques[0].Spec.StartsAfter = []string{}
+				pgs.Spec.Template.Cliques[1].Spec.StartsAfter = []string{"test", "another"}
+				return pgs
+			},
+			expectError:    true,
+			expectedErrMsg: "field is immutable",
+		},
+		{
+			name: "Edge case: Multiple immutable field violations",
+			setupOldPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.Cliques[0].Spec.RoleName = "old-role"
+				pgs.Spec.Template.Cliques[0].Spec.MinAvailable = ptr.To(int32(1))
+				pgs.Spec.Template.Cliques[0].Spec.StartsAfter = []string{"dep1"}
+				return pgs
+			},
+			setupNewPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.Cliques[0].Spec.RoleName = "new-role"
+				pgs.Spec.Template.Cliques[0].Spec.MinAvailable = ptr.To(int32(2))
+				pgs.Spec.Template.Cliques[0].Spec.StartsAfter = []string{"dep1", "dep2"}
+				return pgs
+			},
+			expectError:    true,
+			expectedErrMsg: "field is immutable",
+		},
+		{
+			name: "Edge case: nil MinAvailable changing to non-nil",
+			setupOldPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.Cliques[0].Spec.MinAvailable = nil
+				return pgs
+			},
+			setupNewPGS: func() *grovecorev1alpha1.PodGangSet {
+				pgs := createDummyPodGangSet("test")
+				pgs.Spec.Template.Cliques[0].Spec.MinAvailable = ptr.To(int32(1))
+				return pgs
+			},
+			expectError:    true,
+			expectedErrMsg: "field is immutable",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			oldPGS := tc.setupOldPGS()
+			newPGS := tc.setupNewPGS()
+
+			validator := newPGSValidator(newPGS, admissionv1.Update)
+			err := validator.validateUpdate(oldPGS)
+
+			if tc.expectError {
+				assert.Error(t, err, "Expected validation error for test case: %s", tc.name)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg, "Error message should contain expected text")
+			} else {
+				assert.NoError(t, err, "Expected no validation error for test case: %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestPodCliqueScalingGroupConfigsUpdateValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		oldConfigs     []grovecorev1alpha1.PodCliqueScalingGroupConfig
+		newConfigs     []grovecorev1alpha1.PodCliqueScalingGroupConfig
+		expectedErrors bool
+		expectedErrMsg string
+	}{
+		{
+			name: "same configs - should pass",
+			oldConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1", "clique2"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+			},
+			newConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1", "clique2"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+			},
+			expectedErrors: false,
+		},
+		{
+			name: "different clique names - should fail",
+			oldConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1", "clique2"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+			},
+			newConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1", "clique3"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+			},
+			expectedErrors: true,
+			expectedErrMsg: "field is immutable",
+		},
+		{
+			name: "different min available - should fail",
+			oldConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1", "clique2"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+			},
+			newConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1", "clique2"},
+					MinAvailable: ptr.To(int32(2)),
+				},
+			},
+			expectedErrors: true,
+			expectedErrMsg: "field is immutable",
+		},
+		{
+			name: "adding new config - should fail",
+			oldConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+			},
+			newConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+				{
+					CliqueNames:  []string{"clique2"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+			},
+			expectedErrors: true,
+			expectedErrMsg: "not allowed to add or remove",
+		},
+		{
+			name: "removing config - should fail",
+			oldConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+				{
+					CliqueNames:  []string{"clique2"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+			},
+			newConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+			},
+			expectedErrors: true,
+			expectedErrMsg: "not allowed to add or remove",
+		},
+		{
+			name:           "nil to empty slice - should pass",
+			oldConfigs:     nil,
+			newConfigs:     []grovecorev1alpha1.PodCliqueScalingGroupConfig{},
+			expectedErrors: false,
+		},
+		{
+			name:           "empty slice to nil - should pass",
+			oldConfigs:     []grovecorev1alpha1.PodCliqueScalingGroupConfig{},
+			newConfigs:     nil,
+			expectedErrors: false,
+		},
+		{
+			name: "nil min available in both - should pass",
+			oldConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1"},
+					MinAvailable: nil,
+				},
+			},
+			newConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1"},
+					MinAvailable: nil,
+				},
+			},
+			expectedErrors: false,
+		},
+		{
+			name: "nil to non-nil min available - should fail",
+			oldConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1"},
+					MinAvailable: nil,
+				},
+			},
+			newConfigs: []grovecorev1alpha1.PodCliqueScalingGroupConfig{
+				{
+					CliqueNames:  []string{"clique1"},
+					MinAvailable: ptr.To(int32(1)),
+				},
+			},
+			expectedErrors: true,
+			expectedErrMsg: "field is immutable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fldPath := field.NewPath("spec", "template", "podCliqueScalingGroupConfigs")
+			validationErrors := validatePodCliqueScalingGroupConfigsUpdate(tc.newConfigs, tc.oldConfigs, fldPath)
+
+			if tc.expectedErrors {
+				assert.NotEmpty(t, validationErrors, "Expected validation errors for test case: %s", tc.name)
 				var errorMessages []string
 				for _, err := range validationErrors {
 					errorMessages = append(errorMessages, err.Error())

--- a/operator/test/utils/pclqTemplate.go
+++ b/operator/test/utils/pclqTemplate.go
@@ -18,6 +18,8 @@ package utils
 
 import (
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // PodCliqueTemplateSpecBuilder is a builder for creating PodCliqueTemplateSpec objects.
@@ -80,6 +82,18 @@ func (b *PodCliqueTemplateSpecBuilder) WithAutoScaleMaxReplicas(maximum int32) *
 		b.pclqTemplateSpec.Spec.ScaleConfig = &grovecorev1alpha1.AutoScalingConfig{}
 	}
 	b.pclqTemplateSpec.Spec.ScaleConfig.MaxReplicas = maximum
+	return b
+}
+
+// WithRoleName sets the RoleName for the PodCliqueTemplateSpec.
+func (b *PodCliqueTemplateSpecBuilder) WithRoleName(roleName string) *PodCliqueTemplateSpecBuilder {
+	b.pclqTemplateSpec.Spec.RoleName = roleName
+	return b
+}
+
+// WithPodSpec sets a custom PodSpec for the PodCliqueTemplateSpec.
+func (b *PodCliqueTemplateSpecBuilder) WithPodSpec(podSpec corev1.PodSpec) *PodCliqueTemplateSpecBuilder {
+	b.pclqTemplateSpec.Spec.PodSpec = podSpec
 	return b
 }
 

--- a/operator/test/utils/pgs.go
+++ b/operator/test/utils/pgs.go
@@ -17,6 +17,8 @@
 package utils
 
 import (
+	"time"
+
 	grovecorev1alpha1 "github.com/NVIDIA/grove/operator/api/core/v1alpha1"
 
 	"github.com/google/uuid"
@@ -67,6 +69,18 @@ func (b *PodGangSetBuilder) WithPodCliqueTemplateSpec(pclq *grovecorev1alpha1.Po
 // WithPodCliqueScalingGroupConfig adds a PodCliqueScalingGroupConfig to the PodGangSet.
 func (b *PodGangSetBuilder) WithPodCliqueScalingGroupConfig(config grovecorev1alpha1.PodCliqueScalingGroupConfig) *PodGangSetBuilder {
 	b.pgs.Spec.Template.PodCliqueScalingGroupConfigs = append(b.pgs.Spec.Template.PodCliqueScalingGroupConfigs, config)
+	return b
+}
+
+// WithPriorityClassName sets the PriorityClassName for the PodGangSet.
+func (b *PodGangSetBuilder) WithPriorityClassName(priorityClassName string) *PodGangSetBuilder {
+	b.pgs.Spec.Template.PriorityClassName = priorityClassName
+	return b
+}
+
+// WithTerminationDelay sets the TerminationDelay for the PodGangSet.
+func (b *PodGangSetBuilder) WithTerminationDelay(duration time.Duration) *PodGangSetBuilder {
+	b.pgs.Spec.Template.TerminationDelay = &metav1.Duration{Duration: duration}
 	return b
 }
 

--- a/operator/test/utils/podspec.go
+++ b/operator/test/utils/podspec.go
@@ -32,6 +32,12 @@ func NewPodBuilder() *PodSpecBuilder {
 	}
 }
 
+// WithRestartPolicy sets the restart policy for the PodSpec.
+func (b *PodSpecBuilder) WithRestartPolicy(policy corev1.RestartPolicy) *PodSpecBuilder {
+	b.podSpec.RestartPolicy = policy
+	return b
+}
+
 // Build returns the constructed PodSpec.
 func (b *PodSpecBuilder) Build() *corev1.PodSpec {
 	return b.podSpec
@@ -46,6 +52,5 @@ func createDefaultPodSpec() *corev1.PodSpec {
 				Command: []string{"/bin/sh", "-c", "sleep 2m"},
 			},
 		},
-		RestartPolicy: corev1.RestartPolicyAlways,
 	}
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the validation logic for `PodGangSet` updates and expands the builder utilities used in testing. The main focus is on enforcing immutability and correct ordering for clique and scaling group configurations, as well as enhancing test code flexibility.

### Validation Logic Improvements

* Added new validation for `PodCliqueScalingGroupConfigs` to ensure that scaling group composition and key fields (`cliqueNames`, `minAvailable`) cannot be changed during updates.
* Updated clique validation to enforce immutable fields (`roleName`, `minAvailable`, `startsAfter`) and, for certain startup types, to ensure clique order is not changed. The validation now takes `StartupType` into account for order enforcement.
* Removed the validation that enforced immutability of `PriorityClassName` in the top-level update function, allowing this field to be updated.

### Test Builder Enhancements

* Added new builder methods to `PodGangSetBuilder` for setting `PriorityClassName` and `TerminationDelay`, improving test setup flexibility.
* Added new builder methods to `PodCliqueTemplateSpecBuilder` for setting `RoleName` and custom `PodSpec`, allowing more granular control in tests.
* Added a builder method to `PodSpecBuilder` for setting the `RestartPolicy` field.

### Miscellaneous

* Removed the default setting of `RestartPolicy` in test pod specs, making it optional and configurable via the builder.
* Added missing imports in test utility files for completeness. [[1]](diffhunk://#diff-eecef43b34e56f68c37bf6cdbcc8a1352a612f8f6d7bbcd6d9e853d9344a0e81R21-R22) [[2]](diffhunk://#diff-a1d68e1aabf67a33e527d183ede17351b6d94272df5756724289c9febfe09beeR20-R21)


Fixes #154 