### PR TITLE
Changed the type of webhook secret to kubernetes.io/tls

### DIFF
--- a/operator/charts/templates/webhook-server-cert-secret.yaml
+++ b/operator/charts/templates/webhook-server-cert-secret.yaml
@@ -6,4 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{- include "operator.server.secret.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: ""
+  tls.key: ""
 {{- end }}


### PR DESCRIPTION
Prior to commit `4e3091e` the type of secret used for webhook certificates was `kubernetes.io/tls` but it was removed. This PR re-introduces this change. An empty data with empty `tls.crt` and `tls.key` are added as these are mandatory. These will will replaced by cert-controller when certificates are injected.

Why is this required?
2 reasons:
1. The code line in main defaults the type of secret to `Opaque`. If someone is already using an older version then this will result in an error as the type of a secret is immutable.
2. The correct type for such a secret is `kubernetes.io/tls`