### PR TITLE
Remove validation which prevents setting NodeSelector on PodSpec

### DIFF
--- a/operator/internal/webhook/admission/pcs/validation/podcliqueset.go
+++ b/operator/internal/webhook/admission/pcs/validation/podcliqueset.go
@@ -462,9 +462,6 @@ func (v *pcsValidator) validatePodSpec(spec corev1.PodSpec, fldPath *field.Path)
 			allErrs = append(allErrs, field.Invalid(specFldPath.Child("nodeName"), spec.NodeName, "must not be set"))
 		}
 	}
-	if spec.NodeSelector != nil {
-		allErrs = append(allErrs, field.Invalid(specFldPath.Child("nodeSelector"), spec.NodeSelector, "must not be set"))
-	}
 
 	return warnings, allErrs
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api
-->

#### What this PR does / why we need it:
Validating webhook was preventing setting a `NodeSelector` as part of a `PodSpec`. It was originally thought it would adversely influence network packing but that was an incorrect assumption. Network packing configuration (which will be enhanced in the upcoming PR) needs to always work in tandem with `NodeSelector` configuration setting if explicitly set.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #198 

#### Special notes for your reviewer:

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow NodeSelector to be set as part of PodSpec for a PodClique
```

#### Additional documentation e.g., enhancement proposals, usage docs, etc.:

```docs
None
```
