### PR TITLE
document internal/utils

### DIFF
--- a/operator/internal/utils/componentname.go
+++ b/operator/internal/utils/componentname.go
@@ -38,11 +38,9 @@ func GetPodCliqueSetReplicaIndexFromPodCliqueFQN(pcsName, pclqFQNName string) (i
 	return strconv.Atoi(pclqFQNName[replicaStartIndex:replicaEndIndex])
 }
 
-// GetPodCliqueNameFromPodCliqueFQN get unqualified PodClique name from FQN.
+// GetPodCliqueNameFromPodCliqueFQN extracts the unqualified PodClique name from a fully qualified name.
 func GetPodCliqueNameFromPodCliqueFQN(pclqObjectMeta metav1.ObjectMeta) (string, error) {
 	pclqObjectKey := client.ObjectKey{Name: pclqObjectMeta.Name, Namespace: pclqObjectMeta.Namespace}
-
-	// Check if the PodClique is part of a PodCliqueScalingGroup
 	pcsgName, ok := pclqObjectMeta.Labels[apicommon.LabelPodCliqueScalingGroup]
 	if ok {
 		// get the pcsg replica index
@@ -54,12 +52,10 @@ func GetPodCliqueNameFromPodCliqueFQN(pclqObjectMeta metav1.ObjectMeta) (string,
 		return pclqObjectMeta.Name[len(pclqNamePrefix):], nil
 	}
 
-	// If it is not part of PCSG then the PCLQ is a standalone PCLQ which is part of PCS
 	pcsName, ok := pclqObjectMeta.Labels[apicommon.LabelPartOfKey]
 	if !ok {
 		return "", fmt.Errorf("missing label %s on PodClique: %v", apicommon.LabelPartOfKey, pclqObjectKey)
 	}
-	// Get the PCS replica index
 	pcsReplicaIndex, ok := pclqObjectMeta.Labels[apicommon.LabelPodCliqueSetReplicaIndex]
 	if !ok {
 		return "", fmt.Errorf("missing label %s on PodClique: %v", apicommon.LabelPodCliqueSetReplicaIndex, pclqObjectKey)


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Document internal/utils

#### Special notes for your reviewer:

Prompt: 

Improve the inline documentation for for all golang files under this directory/package. Here are the rules to follow: 

* Use concise idiomatic go documentation principles.  
* Ensure correctness. 
* Add some minimal inline documentation above complex code blocks when to explain the intent of the code. 
* Don't document code that is clearly self documenting. 
* Blocks of code should only have a comment describing them if it is practical and valuable. 
* Don't change the code or variable names. 
* All functions to should have concise accurate documentation with the exception of command "main" functions which are obviously entry points. 
* Document field structs but don't duplicate the field documentation above. 
* Avoid duplicate documentation, just pick the most appropriate place.
* Large or complex blocks of code that aren't self documenting should be documented. 
* Avoid re-writing any existing documentation unless it's incomplete, or incorrect


Example of documentation that isn't useful and should be avoided: 
  ```// log is the global logger instance configured for the grove init container.
// It uses JSON format at INFO level for structured logging.
var (
 log = logger.MustNewLogger(false, configv1alpha1.InfoLevel, configv1alpha1.LogFormatJSON).WithName("grove-initc")
)```. 

Examples of documentation that doesn't add value: 
```  // Parse the replica count as an integer
  replicas, err := strconv.Atoi(nameAndMinAvailable[1])
  if err != nil {
   return nil, groveerr.WrapError(err, errCodeInvalidInput, operationParseFlag, "failed to convert replicas to int")
  }
```
```
  // Store the PodClique name and its minimum available replicas
  podCliqueDependencies[strings.TrimSpace(nameAndMinAvailable[0])] = replicas
```
```
// Initialize the configuration with empty PodClique list
 config := CLIOptions{
  podCliques: make([]string, 0),
 }
```
```
 // Register all command line flags
 config.RegisterFlags(pflag.CommandLine)
 // Parse the command line arguments
 pflag.Parse()
```

```
 // Get the in-cluster REST configuration
 restConfig, err := rest.InClusterConfig()
```
```
// Get the pod informer from the factory
typedInformer := factory.Core().V1().Pods().Informer()
```

Systematically check every golang file under this directory is documented as per the instructions above. 

#### Does this PR introduce a API change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None

```


